### PR TITLE
Add a note to mention hard-coded test name

### DIFF
--- a/website/docs/tests/with-test.md
+++ b/website/docs/tests/with-test.md
@@ -17,6 +17,10 @@ The full structure of the `Test` resource is documented [here](../apis/chainsaw.
 A `Test` resource is self contained and fully represents a test.
 Therefore the loading process is straightforward, Chainsaw loads the `Test` and adds it to the collection of tests to be processed.
 
+!!! note
+
+    For the time being, the `Test` based approach requires the file name to match `chainsaw-test.yaml`. This will be configurable by a command flag in the future.
+
 ## Example
 
 ### chainsaw-test.yaml


### PR DESCRIPTION
With respect to issue #389, this PR suggests to add a short comment about the enforced usage of the specific `chainsaw-test.yam` filename at the beginning of the [Test based syntax](https://kyverno.github.io/chainsaw/tests/with-test/) page until you consider adding a command line flag for this purpose.