### PR TITLE
fix: kuttl migration failure in case of unsupported name

### DIFF
--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -19,3 +19,7 @@ Release notes for `TODO`.
 
 ## :guitar: Misc :guitar:
 -->
+
+## :wrench: Fixes :wrench:
+
+- Fixed a kuttl migration failure in case of unsupported file name

--- a/pkg/commands/kuttl/migrate/command.go
+++ b/pkg/commands/kuttl/migrate/command.go
@@ -135,6 +135,10 @@ func migrate(out io.Writer, path string, resource unstructured.Unstructured) (me
 			}
 			return configuration, nil
 		case "TestStep":
+			groups := discovery.StepFileName.FindStringSubmatch(filepath.Base(path))
+			if len(groups) < 3 {
+				return nil, nil
+			}
 			fmt.Fprintf(out, "Converting %s in %s...\n", "TestStep", path)
 			step, err := testStep(resource)
 			if err != nil {
@@ -142,7 +146,6 @@ func migrate(out io.Writer, path string, resource unstructured.Unstructured) (me
 				return nil, err
 			}
 			if step.GetName() == "" {
-				groups := discovery.StepFileName.FindStringSubmatch(filepath.Base(path))
 				step.SetName(groups[2])
 			}
 			return step, nil


### PR DESCRIPTION
Fixed a kuttl migration failure in case of unsupported name.