### PR TITLE
fix: invalid name in kuttl migrate command

### DIFF
--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -23,3 +23,4 @@ Release notes for `TODO`.
 ## :wrench: Fixes :wrench:
 
 - Fixed a kuttl migration failure in case of unsupported file name
+- Fixed a potential invalid name when migrating a kuttl test step

--- a/pkg/commands/kuttl/migrate/command.go
+++ b/pkg/commands/kuttl/migrate/command.go
@@ -146,7 +146,7 @@ func migrate(out io.Writer, path string, resource unstructured.Unstructured) (me
 				return nil, err
 			}
 			if step.GetName() == "" {
-				step.SetName(groups[2])
+				step.SetName(strings.ReplaceAll(groups[2], "_", "-"))
 			}
 			return step, nil
 		case "TestAssert":


### PR DESCRIPTION
Fixed invalid name in kuttl migrate command.