### PR TITLE
fix: force lower case name in kuttl migrate

### DIFF
--- a/pkg/commands/kuttl/migrate/command.go
+++ b/pkg/commands/kuttl/migrate/command.go
@@ -146,7 +146,7 @@ func migrate(out io.Writer, path string, resource unstructured.Unstructured) (me
 				return nil, err
 			}
 			if step.GetName() == "" {
-				step.SetName(strings.ReplaceAll(groups[2], "_", "-"))
+				step.SetName(strings.ToLower(strings.ReplaceAll(groups[2], "_", "-")))
 			}
 			return step, nil
 		case "TestAssert":


### PR DESCRIPTION
Force lower case name in kuttl migrate.