### PR TITLE
fix: don't show cmd/script logs if empty

### DIFF
--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -10,8 +10,6 @@ Release notes for `TODO`.
 
 ## :boat: Tutorials :boat:
 
-## :wrench: Fixes :wrench:
-
 ## :books: Docs :books:
 -->
 
@@ -23,6 +21,10 @@ Release notes for `TODO`.
 
 - Added support to register Chainsaw specific JMESPath functions for use in assertion trees
 - Added inline manifest support to `assert` and `error` operations
+
+## :wrench: Fixes :wrench:
+
+- Don't show `command` or `script` logs if there's nothing to show
 
 ## :guitar: Misc :guitar:
 

--- a/pkg/runner/operations/command/command.go
+++ b/pkg/runner/operations/command/command.go
@@ -41,7 +41,9 @@ func (o *operation) Exec(ctx context.Context) (_err error) {
 	}()
 	if !o.command.SkipLogOutput {
 		defer func() {
-			logger.Log(logging.Command, logging.LogStatus, color.BoldFgCyan, output.Sections()...)
+			if sections := output.Sections(); len(sections) != 0 {
+				logger.Log(logging.Command, logging.LogStatus, color.BoldFgCyan, sections...)
+			}
 		}()
 	}
 	args := expand(map[string]string{"NAMESPACE": o.namespace}, o.command.Args...)

--- a/pkg/runner/operations/script/script.go
+++ b/pkg/runner/operations/script/script.go
@@ -41,7 +41,9 @@ func (o *operation) Exec(ctx context.Context) (_err error) {
 	}()
 	if !o.script.SkipLogOutput {
 		defer func() {
-			logger.Log(logging.Script, logging.LogStatus, color.BoldFgCyan, output.Sections()...)
+			if sections := output.Sections(); len(sections) != 0 {
+				logger.Log(logging.Script, logging.LogStatus, color.BoldFgCyan, sections...)
+			}
 		}()
 	}
 	cmd := exec.CommandContext(ctx, "sh", "-c", o.script.Content) //nolint:gosec


### PR DESCRIPTION
Don't show cmd/script logs if empty.