### PR TITLE
refactor: timeouts management (part 2)

### DIFF
--- a/pkg/apis/v1alpha1/timeouts.go
+++ b/pkg/apis/v1alpha1/timeouts.go
@@ -66,3 +66,28 @@ func (t Timeouts) ErrorDuration() time.Duration {
 func (t Timeouts) ExecDuration() time.Duration {
 	return durationOrDefault(t.Exec, DefaultExecTimeout)
 }
+
+func (t Timeouts) Combine(override *Timeouts) Timeouts {
+	if override == nil {
+		return t
+	}
+	if override.Apply != nil {
+		t.Apply = override.Apply
+	}
+	if override.Assert != nil {
+		t.Assert = override.Assert
+	}
+	if override.Error != nil {
+		t.Error = override.Error
+	}
+	if override.Delete != nil {
+		t.Delete = override.Delete
+	}
+	if override.Cleanup != nil {
+		t.Cleanup = override.Cleanup
+	}
+	if override.Exec != nil {
+		t.Exec = override.Exec
+	}
+	return t
+}

--- a/pkg/runner/timeout/timeout.go
+++ b/pkg/runner/timeout/timeout.go
@@ -3,35 +3,34 @@ package timeout
 import (
 	"time"
 
-	"github.com/kyverno/chainsaw/pkg/apis/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Combine(config v1alpha1.Timeouts, next ...*v1alpha1.Timeouts) v1alpha1.Timeouts {
-	for _, next := range next {
-		if next != nil {
-			if next.Apply != nil {
-				config.Apply = next.Apply
-			}
-			if next.Assert != nil {
-				config.Assert = next.Assert
-			}
-			if next.Error != nil {
-				config.Error = next.Error
-			}
-			if next.Delete != nil {
-				config.Delete = next.Delete
-			}
-			if next.Cleanup != nil {
-				config.Cleanup = next.Cleanup
-			}
-			if next.Exec != nil {
-				config.Exec = next.Exec
-			}
-		}
-	}
-	return config
-}
+// func Combine(config v1alpha1.Timeouts, next ...*v1alpha1.Timeouts) v1alpha1.Timeouts {
+// 	for _, next := range next {
+// 		if next != nil {
+// 			if next.Apply != nil {
+// 				config.Apply = next.Apply
+// 			}
+// 			if next.Assert != nil {
+// 				config.Assert = next.Assert
+// 			}
+// 			if next.Error != nil {
+// 				config.Error = next.Error
+// 			}
+// 			if next.Delete != nil {
+// 				config.Delete = next.Delete
+// 			}
+// 			if next.Cleanup != nil {
+// 				config.Cleanup = next.Cleanup
+// 			}
+// 			if next.Exec != nil {
+// 				config.Exec = next.Exec
+// 			}
+// 		}
+// 	}
+// 	return config
+// }
 
 func Get(operation *metav1.Duration, fallback time.Duration) *time.Duration {
 	if operation != nil {


### PR DESCRIPTION
Refactor timeouts management (part 2).
Combined timeouts are computed only once per test/step.