### PR TITLE
feat: add --readme-file flag to generate docs command

### DIFF
--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -20,6 +20,10 @@ Release notes for `TODO`.
 
 - GitHub action was moved to a dedicated repository https://github.com/kyverno/action-install-chainsaw
 
+## 💫 New features 💫
+
+- Added `--readme-file` flag to `chainsaw generate docs` command to customize the name of the generated file
+
 ## 🔧 Fixes 🔧
 
 - Fixed an invalid error check in `chainsaw docs` command

--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -11,8 +11,6 @@ Release notes for `TODO`.
 
 ## ⛵ Tutorials ⛵
 
-## 🔧 Fixes 🔧
-
 ## 📚 Docs 📚
 
 ## 🎸 Misc 🎸
@@ -21,3 +19,7 @@ Release notes for `TODO`.
 ## ‼️ Breaking changes ‼️
 
 - GitHub action was moved to a dedicated repository https://github.com/kyverno/action-install-chainsaw
+
+## 🔧 Fixes 🔧
+
+- Fixed an invalid error check in `chainsaw docs` command

--- a/pkg/commands/docs/options.go
+++ b/pkg/commands/docs/options.go
@@ -31,7 +31,10 @@ func (o options) execute(root *cobra.Command) error {
 		prepender = websitePrepender
 		linkHandler = websiteLinkHandler
 	}
-	if _, err := os.Stat(o.path); errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(o.path); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
 		if err := os.MkdirAll(o.path, os.ModeDir|os.ModePerm); err != nil {
 			return err
 		}

--- a/pkg/commands/generate/docs/command.go
+++ b/pkg/commands/generate/docs/command.go
@@ -16,8 +16,9 @@ import (
 var docsTemplate string
 
 type options struct {
-	testFile string
-	testDirs []string
+	testFile   string
+	readmeFile string
+	testDirs   []string
 }
 
 func Command() *cobra.Command {
@@ -38,7 +39,7 @@ func Command() *cobra.Command {
 			}
 			for _, test := range tests {
 				if test.Err == nil {
-					file, err := os.Create(filepath.Join(test.BasePath, "README.md"))
+					file, err := os.Create(filepath.Join(test.BasePath, options.readmeFile))
 					if err != nil {
 						return err
 					}
@@ -55,6 +56,7 @@ func Command() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&options.testFile, "test-file", "chainsaw-test.yaml", "Name of the test file")
+	cmd.Flags().StringVar(&options.readmeFile, "readme-file", "README.md", "Name of the generated docs file")
 	cmd.Flags().StringArrayVar(&options.testDirs, "test-dir", []string{}, "Directories containing test cases to run")
 	return cmd
 }

--- a/website/docs/commands/chainsaw_generate_docs.md
+++ b/website/docs/commands/chainsaw_generate_docs.md
@@ -10,6 +10,7 @@ chainsaw generate docs [flags]
 
 ```
   -h, --help                   help for docs
+      --readme-file string     Name of the generated docs file (default "README.md")
       --test-dir stringArray   Directories containing test cases to run
       --test-file string       Name of the test file (default "chainsaw-test.yaml")
 ```


### PR DESCRIPTION
Add `--readme-file` flag to generate docs command.