### PR TITLE
fix: migrate kuttl commands are applied last instead of first

### DIFF
--- a/pkg/commands/migrate/kuttl/config/command.go
+++ b/pkg/commands/migrate/kuttl/config/command.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	kuttlapi "github.com/kudobuilder/kuttl/pkg/apis/testharness/v1beta1"
@@ -69,9 +70,13 @@ func execute(out io.Writer, save, cleanup bool, path string) error {
 	return nil
 }
 
+func isKuttl(resource unstructured.Unstructured) bool {
+	return strings.HasPrefix(resource.GetAPIVersion(), "kuttl.dev/")
+}
+
 func migrate(out io.Writer, path string, resource unstructured.Unstructured) (*v1alpha1.Configuration, error) {
 	fmt.Fprintf(out, "Converting config %s ...\n", path)
-	if resource.GetAPIVersion() == "kuttl.dev/v1beta1" {
+	if isKuttl(resource) {
 		switch resource.GetKind() {
 		case "TestSuite":
 			configuration, err := testSuite(resource)

--- a/testdata/commands/migrate/kuttl/tests/out.txt
+++ b/testdata/commands/migrate/kuttl/tests/out.txt
@@ -15,6 +15,14 @@ spec:
         name: nginx
     name: step-01
     try:
+    - script:
+        content: echo "hello world"
+        skipLogOutput: true
+    - command:
+        args:
+        - hello world
+        entrypoint: echo
+        skipLogOutput: true
     - delete:
         ref:
           apiVersion: v1
@@ -30,14 +38,6 @@ spec:
         ref:
           apiVersion: v1
           kind: Pod
-    - script:
-        content: echo "hello world"
-        skipLogOutput: true
-    - command:
-        args:
-        - hello world
-        entrypoint: echo
-        skipLogOutput: true
   - catch:
     - command:
         args:
@@ -49,6 +49,14 @@ spec:
         entrypoint: sleep
     name: step-02
     try:
+    - script:
+        content: echo "hello world"
+        skipLogOutput: true
+    - command:
+        args:
+        - hello world
+        entrypoint: echo
+        skipLogOutput: true
     - delete:
         ref:
           apiVersion: v1
@@ -64,12 +72,4 @@ spec:
         ref:
           apiVersion: v1
           kind: Pod
-    - script:
-        content: echo "hello world"
-        skipLogOutput: true
-    - command:
-        args:
-        - hello world
-        entrypoint: echo
-        skipLogOutput: true
 

--- a/testdata/kuttl/chainsaw-test.yaml
+++ b/testdata/kuttl/chainsaw-test.yaml
@@ -14,6 +14,14 @@ spec:
         name: nginx
     name: step-01
     try:
+    - script:
+        content: echo "hello world"
+        skipLogOutput: true
+    - command:
+        args:
+        - hello world
+        entrypoint: echo
+        skipLogOutput: true
     - delete:
         ref:
           apiVersion: v1
@@ -29,14 +37,6 @@ spec:
         ref:
           apiVersion: v1
           kind: Pod
-    - script:
-        content: echo "hello world"
-        skipLogOutput: true
-    - command:
-        args:
-        - hello world
-        entrypoint: echo
-        skipLogOutput: true
   - catch:
     - command:
         args:
@@ -48,6 +48,14 @@ spec:
         entrypoint: sleep
     name: step-02
     try:
+    - script:
+        content: echo "hello world"
+        skipLogOutput: true
+    - command:
+        args:
+        - hello world
+        entrypoint: echo
+        skipLogOutput: true
     - delete:
         ref:
           apiVersion: v1
@@ -63,11 +71,3 @@ spec:
         ref:
           apiVersion: v1
           kind: Pod
-    - script:
-        content: echo "hello world"
-        skipLogOutput: true
-    - command:
-        args:
-        - hello world
-        entrypoint: echo
-        skipLogOutput: true


### PR DESCRIPTION
## Explanation

Fix `chainsaw migrate kuttl tests ...` commands applied last instead of first.
This PR also adds support for `kuttl.dev/v1` and only splits files when necessary.
