### PR TITLE
chore: add the Norwegian Mapping Authority as a user

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -11,6 +11,7 @@ The list of organizations that have publicly shared the usage of Chainsaw:
 | [Kyverno](https://kyverno.io) | Running all end to end tests for both Kyverno and the policies catalog |
 | [Redis-operator](https://github.com/OT-CONTAINER-KIT/redis-operator) | Chainsaw helped a lot for declarative assertion of Redis Cluster state against various e2e test  |
 | [rbac-manager](https://github.com/fairwindsops/rbac-manager) | Chainsaw replaced and improved upon our bash test framework for testing the RbacDefinition CRD |
+| [skiperator](https://github.com/kartverket/skiperator) (Norwegian Mapping Authority) | Chainsaw replaced kuttl and made our tests more reliable |
 
 <!-- append the line below to the table
 | [name](URL) | brief description of how you are using Chainsaw | 


### PR DESCRIPTION
Adds the [skiperator](https://github.com/kartverket/skiperator) project by the [Norwegian Mapping Authority](https://www.kartverket.no/en) to ADOPTERS.md.