### PR TITLE
fix: do not apply kuttl migration if already migrated

### DIFF
--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -13,9 +13,11 @@ Release notes for `TODO`.
 
 ## ⛵ Tutorials ⛵
 
-## 🔧 Fixes 🔧
-
 ## 📚 Docs 📚
 
 ## 🎸 Misc 🎸
 -->
+
+## 🔧 Fixes 🔧
+
+- Fixed an issue when running `chainsaw migrate kuttl tests` twice on the same folder

--- a/pkg/commands/migrate/tests/command.go
+++ b/pkg/commands/migrate/tests/command.go
@@ -52,6 +52,9 @@ func execute(out io.Writer, save, cleanup bool, paths ...string) error {
 }
 
 func processFolder(out io.Writer, folder string, save, cleanup bool) error {
+	if _, err := os.Stat(filepath.Join(folder, "chainsaw-test.yaml")); err == nil {
+		return nil
+	}
 	steps, err := discovery.TryFindStepFiles(folder)
 	if err != nil {
 		fmt.Fprintf(out, "ERROR: failed to collect test files: %v\n", err)


### PR DESCRIPTION
## Explanation

Do not apply kuttl migration if already migrated.
