### PR TITLE
Add Keptn to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -8,6 +8,7 @@ The list of organizations that have publicly shared the usage of Chainsaw:
 
 | Organization | Success Story |
 |:--|:--|
+| [Keptn](https://github.com/keptn/lifecycle-toolkit)| Chainsaw replaced Kuttl, and helped us get rid of many unreadable bash scripts |
 | [Kyverno](https://kyverno.io) | Running all end to end tests for both Kyverno and the policies catalog |
 | [Redis-operator](https://github.com/OT-CONTAINER-KIT/redis-operator) | Chainsaw helped a lot for declarative assertion of Redis Cluster state against various e2e test  |
 | [rbac-manager](https://github.com/fairwindsops/rbac-manager) | Chainsaw replaced and improved upon our bash test framework for testing the RbacDefinition CRD |


### PR DESCRIPTION
## Explanation

We just started adopting Chainsaw in our [main repo](https://github.com/keptn/lifecycle-toolkit/tree/main/test/chainsaw), we recently voted to abandon Kuttl in favor of it.

## Related issue

https://github.com/keptn/lifecycle-toolkit/issues/2949#issuecomment-1931643542 

Many thanks to @eddycharly for helping us 🚀 