### PR TITLE
feat(commands): accept stdin in assert cmd

### DIFF
--- a/pkg/commands/assert/command.go
+++ b/pkg/commands/assert/command.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/jmespath-community/go-jmespath/pkg/binding"
 	"github.com/kyverno/chainsaw/pkg/apis/v1alpha1"
-	"github.com/kyverno/chainsaw/pkg/client"
+	ctrlClient "github.com/kyverno/chainsaw/pkg/client"
 	"github.com/kyverno/chainsaw/pkg/resource"
 	runnerclient "github.com/kyverno/chainsaw/pkg/runner/client"
-	"github.com/kyverno/chainsaw/pkg/runner/namespacer"
+	nspacer "github.com/kyverno/chainsaw/pkg/runner/namespacer"
 	opassert "github.com/kyverno/chainsaw/pkg/runner/operations/assert"
 	restutils "github.com/kyverno/chainsaw/pkg/utils/rest"
 	"github.com/kyverno/kyverno/ext/output/color"
@@ -36,52 +36,10 @@ func Command() *cobra.Command {
 		Args:         cobra.RangeArgs(0, 1),
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 && opts.filePath == "" {
-				opts.filePath = args[0]
-			} else if opts.filePath == "" {
-				return fmt.Errorf("either a file path as an argument or the --file flag must be provided")
-			}
-			return nil
+			return preRunE(&opts, cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			color.Init(opts.noColor, true)
-			out := cmd.OutOrStdout()
-			var resources []unstructured.Unstructured
-			var err error
-
-			if opts.filePath == "-" {
-				content, readErr := io.ReadAll(cmd.InOrStdin())
-				if readErr != nil {
-					return fmt.Errorf("failed to read from stdin: %w", readErr)
-				}
-				resources, err = resource.Parse(content, false)
-				if err != nil {
-					return fmt.Errorf("failed to parse stdin content: %w", err)
-				}
-			} else {
-				resources, err = resource.Load(opts.filePath, false)
-				if err != nil {
-					return fmt.Errorf("failed to load file '%s': %w", opts.filePath, err)
-				}
-			}
-
-			cfg, err := restutils.Config(opts.kubeConfigOverrides)
-			if err != nil {
-				return err
-			}
-			client, err := client.New(cfg)
-			if err != nil {
-				return err
-			}
-			client = runnerclient.New(client)
-			namespacer := namespacer.New(client, opts.namespace)
-			for _, resource := range resources {
-				if err := assert(opts, client, resource, namespacer); err != nil {
-					return fmt.Errorf("assertion failed: %w", err)
-				}
-			}
-			fmt.Fprintln(out, "Assertion(s) PASSED")
-			return nil
+			return runE(opts, cmd, nil, nil)
 		},
 	}
 	cmd.Flags().StringVarP(&opts.filePath, "file", "f", "", "Path to the file to assert or '-' to read from stdin")
@@ -92,7 +50,61 @@ func Command() *cobra.Command {
 	return cmd
 }
 
-func assert(opts options, client client.Client, resource unstructured.Unstructured, namespacer namespacer.Namespacer) error {
+func preRunE(opts *options, cmd *cobra.Command, args []string) error {
+	if len(args) > 0 && opts.filePath == "" {
+		opts.filePath = args[0]
+	} else if opts.filePath == "" {
+		return fmt.Errorf("either a file path as an argument or the --file flag must be provided")
+	}
+	return nil
+}
+
+func runE(opts options, cmd *cobra.Command, client ctrlClient.Client, namespacer nspacer.Namespacer) error {
+	color.Init(opts.noColor, true)
+	out := cmd.OutOrStdout()
+	var resources []unstructured.Unstructured
+	var err error
+
+	if opts.filePath == "-" {
+		content, readErr := io.ReadAll(cmd.InOrStdin())
+		if readErr != nil {
+			return fmt.Errorf("failed to read from stdin: %w", readErr)
+		}
+		resources, err = resource.Parse(content, false)
+		if err != nil {
+			return fmt.Errorf("failed to parse stdin content: %w", err)
+		}
+	} else {
+		resources, err = resource.Load(opts.filePath, false)
+		if err != nil {
+			return fmt.Errorf("failed to load file '%s': %w", opts.filePath, err)
+		}
+	}
+
+	if client == nil {
+		cfg, err := restutils.Config(opts.kubeConfigOverrides)
+		if err != nil {
+			return err
+		}
+		newClient, err := ctrlClient.New(cfg)
+		if err != nil {
+			return err
+		}
+		client = runnerclient.New(newClient)
+	}
+	if namespacer == nil {
+		namespacer = nspacer.New(client, opts.namespace)
+	}
+	for _, resource := range resources {
+		if err := assert(opts, client, resource, namespacer); err != nil {
+			return fmt.Errorf("assertion failed: %w", err)
+		}
+	}
+	fmt.Fprintln(out, "Assertion(s) PASSED")
+	return nil
+}
+
+func assert(opts options, client ctrlClient.Client, resource unstructured.Unstructured, namespacer nspacer.Namespacer) error {
 	ctx, cancel := context.WithTimeout(context.Background(), opts.timeout.Duration)
 	defer cancel()
 	op := opassert.New(client, resource, namespacer, binding.NewBindings(), false)

--- a/pkg/commands/assert/command_test.go
+++ b/pkg/commands/assert/command_test.go
@@ -39,7 +39,7 @@ func Test_Execute(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "no args",
+			name:    "no args and no flags",
 			args:    []string{"assert"},
 			wantErr: true,
 		},

--- a/pkg/commands/assert/command_test.go
+++ b/pkg/commands/assert/command_test.go
@@ -1,0 +1,243 @@
+package assert
+
+import (
+	"bytes"
+	"context"
+	"path"
+	"testing"
+	"time"
+
+	fakeClient "github.com/kyverno/chainsaw/pkg/client/testing"
+	fakeNamespacer "github.com/kyverno/chainsaw/pkg/runner/namespacer/testing"
+	"github.com/spf13/cobra"
+	testify "github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Test_preRunE(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		initialOpt  *options
+		expectedOpt *options
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "No args and no filePath set",
+			args: []string{},
+			initialOpt: &options{
+				filePath: "",
+			},
+			wantErr: true,
+			errMsg:  "either a file path as an argument or the --file flag must be provided",
+		},
+		{
+			name: "Args provided and filePath not set",
+			args: []string{"./path/to/config.yaml"},
+			initialOpt: &options{
+				filePath: "",
+			},
+			expectedOpt: &options{
+				filePath: "./path/to/config.yaml",
+			},
+			wantErr: false,
+		},
+		{
+			name: "filePath already set, no args",
+			args: []string{},
+			initialOpt: &options{
+				filePath: "./already/set/path.yaml",
+			},
+			expectedOpt: &options{
+				filePath: "./already/set/path.yaml",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			err := preRunE(tt.initialOpt, cmd, tt.args)
+			if tt.wantErr {
+				testify.Error(t, err)
+				testify.Equal(t, tt.errMsg, err.Error())
+			} else {
+				testify.NoError(t, err)
+				testify.Equal(t, tt.expectedOpt.filePath, tt.initialOpt.filePath)
+			}
+		})
+	}
+}
+
+func Test_runE(t *testing.T) {
+	basePath := path.Join("..", "..", "..", "testdata", "commands", "assert")
+	tests := []struct {
+		name       string
+		setupFunc  func() *cobra.Command
+		opts       options
+		client     *fakeClient.FakeClient
+		nspacer    *fakeNamespacer.FakeNamespacer
+		wantErrMsg string
+		wantErr    bool
+	}{
+		{
+			name: "Success case - file input",
+			setupFunc: func() *cobra.Command {
+				cmd := &cobra.Command{}
+				cmd.Args = cobra.RangeArgs(0, 1)
+				cmd.SilenceUsage = true
+				cmd.SetOut(bytes.NewBufferString(""))
+				return cmd
+			},
+			opts: options{
+				filePath:  path.Join(basePath, "assert.yaml"),
+				noColor:   true,
+				namespace: "default",
+				timeout:   metav1.Duration{Duration: 5 * time.Second},
+			},
+			client: &fakeClient.FakeClient{
+				GetFn: func(ctx context.Context, call int, key ctrlclient.ObjectKey, obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+					obj.(*unstructured.Unstructured).Object = map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]any{
+							"name": "quick-start",
+						},
+						"data": map[string]any{
+							"foo": "bar",
+						},
+					}
+					return nil
+				},
+			},
+			nspacer: &fakeNamespacer.FakeNamespacer{
+				ApplyFn: func(obj ctrlclient.Object, call int) error {
+					return nil
+				},
+				GetNamespaceFn: func(call int) string {
+					return "default"
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Failure case - file input",
+			setupFunc: func() *cobra.Command {
+				cmd := &cobra.Command{}
+				cmd.Args = cobra.RangeArgs(0, 1)
+				cmd.SilenceUsage = true
+				cmd.SetOut(bytes.NewBufferString(""))
+				return cmd
+			},
+			opts: options{
+				filePath:  path.Join(basePath, "assert.yaml"),
+				noColor:   true,
+				namespace: "default",
+				timeout:   metav1.Duration{Duration: 5 * time.Second},
+			},
+			client: &fakeClient.FakeClient{
+				GetFn: func(ctx context.Context, call int, key ctrlclient.ObjectKey, obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+					obj.(*unstructured.Unstructured).Object = map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]any{
+							"name": "quick-start",
+						},
+						"data": map[string]any{
+							"bar": "foo",
+						},
+					}
+					return nil
+				},
+			},
+			nspacer: &fakeNamespacer.FakeNamespacer{
+				ApplyFn: func(obj ctrlclient.Object, call int) error {
+					return nil
+				},
+				GetNamespaceFn: func(call int) string {
+					return "default"
+				},
+			},
+			wantErrMsg: "assertion failed: ------------------------\n" +
+				"v1/ConfigMap/quick-start\n" +
+				"------------------------\n" +
+				"* data.foo: Invalid value: \"null\": Expected value: \"bar\"\n\n" +
+				"--- expected\n" +
+				"+++ actual\n" +
+				"@@ -1,6 +1,5 @@\n" +
+				" apiVersion: v1\n" +
+				"-data:\n" +
+				"-  foo: bar\n" +
+				"+data: {}\n" +
+				" kind: ConfigMap\n" +
+				" metadata:\n" +
+				"   name: quick-start\n",
+			wantErr: true,
+		},
+		{
+			name: "Success case - stdin input",
+			setupFunc: func() *cobra.Command {
+				cmd := &cobra.Command{}
+				cmd.Args = cobra.RangeArgs(0, 1)
+				cmd.SilenceUsage = true
+				cmd.SetOut(bytes.NewBufferString(""))
+				cmd.SetIn(bytes.NewBufferString(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quick-start
+data:
+  foo: bar`))
+				return cmd
+			},
+			opts: options{
+				filePath:  "-",
+				noColor:   true,
+				namespace: "default",
+				timeout:   metav1.Duration{Duration: 5 * time.Second},
+			},
+			client: &fakeClient.FakeClient{
+				GetFn: func(ctx context.Context, call int, key ctrlclient.ObjectKey, obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+					obj.(*unstructured.Unstructured).Object = map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]any{
+							"name": "quick-start",
+						},
+						"data": map[string]any{
+							"foo": "bar",
+						},
+					}
+					return nil
+				},
+			},
+			nspacer: &fakeNamespacer.FakeNamespacer{
+				ApplyFn: func(obj ctrlclient.Object, call int) error {
+					return nil
+				},
+				GetNamespaceFn: func(call int) string {
+					return "default"
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.setupFunc()
+			err := runE(tt.opts, cmd, tt.client, tt.nspacer)
+			if tt.wantErr {
+				testify.Error(t, err)
+				if err != nil {
+					testify.Equal(t, tt.wantErrMsg, err.Error())
+				}
+			} else {
+				testify.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/utils/reader/mockstdin.go
+++ b/pkg/utils/reader/mockstdin.go
@@ -1,0 +1,9 @@
+package reader
+
+import "errors"
+
+type ErrReader struct{}
+
+func (e *ErrReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("error reading from stdin")
+}

--- a/testdata/commands/assert/assert.yaml
+++ b/testdata/commands/assert/assert.yaml
@@ -1,0 +1,6 @@
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: quick-start
+  data:
+    foo: bar

--- a/testdata/commands/assert/help.txt
+++ b/testdata/commands/assert/help.txt
@@ -1,0 +1,30 @@
+Evaluate assertion
+
+Usage:
+  chainsaw assert [flags] [FILE]
+
+Flags:
+  -f, --file string                         Path to the file to assert or '-' to read from stdin
+  -h, --help                                help for assert
+      --kube-as string                      Username to impersonate for the operation
+      --kube-as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --kube-as-uid string                  UID to impersonate for the operation
+      --kube-certificate-authority string   Path to a cert file for the certificate authority
+      --kube-client-certificate string      Path to a client certificate file for TLS
+      --kube-client-key string              Path to a client key file for TLS
+      --kube-cluster string                 The name of the kubeconfig cluster to use
+      --kube-context string                 The name of the kubeconfig context to use
+      --kube-disable-compression            If true, opt-out of response compression for all requests to the server
+      --kube-insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -n, --kube-namespace string               If present, the namespace scope for this CLI request
+      --kube-password string                Password for basic authentication to the API server
+      --kube-proxy-url string               If provided, this URL will be used to connect via proxy
+      --kube-request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --kube-server string                  The address and port of the Kubernetes API server
+      --kube-tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --kube-token string                   Bearer token for authentication to the API server
+      --kube-user string                    The name of the kubeconfig user to use
+      --kube-username string                Username for basic authentication to the API server
+      --namespace string                    Namespace to use (default "default")
+      --no-color                            Removes output colors
+      --timeout duration                    The assert timeout to use (default 30s)

--- a/website/docs/commands/chainsaw_assert.md
+++ b/website/docs/commands/chainsaw_assert.md
@@ -3,12 +3,13 @@
 Evaluate assertion
 
 ```
-chainsaw assert [flags]
+chainsaw assert [flags] [FILE]
 ```
 
 ### Options
 
 ```
+  -f, --file string                         Path to the file to assert or '-' to read from stdin
   -h, --help                                help for assert
       --kube-as string                      Username to impersonate for the operation
       --kube-as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.


### PR DESCRIPTION
## Explanation

Add a flag `--file` and short `-f` while supporting the current approach of accepting files.


## Related issue

Fixes https://github.com/kyverno/chainsaw/issues/878


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
