### PR TITLE
fix: separate unit tests from codecov upload

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,23 @@ jobs:
       run: |
         set -e
         make tests
+    - name: Upload coverage
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      with:
+        name: coverage.out
+        path: coverage.out
+        retention-days: 1
+        if-no-files-found: error
+
+  upload-to-codecov:
+    needs:
+      - unit-tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download coverage
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: coverage.out
     - name: Upload Report to Codecov
       uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
       with:


### PR DESCRIPTION
## Explanation

Separate unit tests from codecov upload
