### PR TITLE
docs: fix typo in docs

### DIFF
--- a/website/docs/operations/create.md
+++ b/website/docs/operations/create.md
@@ -61,6 +61,7 @@ Below is an example of using `create` in a `Test` resource.
         - create:
             file: https://raw.githubusercontent.com/kyverno/chainsaw/main/testdata/resource/valid.yaml
         # ...
+    ```
 
 !!! example "Using an inline resource"
 


### PR DESCRIPTION
## Explanation
Fix typo 

## Related issue

Fixes : https://github.com/kyverno/chainsaw/issues/906

## Proposed Changes
Add ```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->