### PR TITLE
fix: missing operations in build docs

### DIFF
--- a/pkg/commands/build/docs/docs.tmpl
+++ b/pkg/commands/build/docs/docs.tmpl
@@ -11,6 +11,8 @@ create
 delete
 {{- else if .Error -}}
 error
+{{- else if .Patch -}}
+patch
 {{- else if .Script -}}
 script
 {{- else if .Sleep -}}
@@ -27,6 +29,8 @@ events
 pod logs
 {{- else if .Describe -}}
 describe
+{{- else if .Get -}}
+get
 {{- else if .Script -}}
 script
 {{- else if .Sleep -}}
@@ -43,6 +47,8 @@ events
 pod logs
 {{- else if .Describe -}}
 describe
+{{- else if .Get -}}
+get
 {{- else if .Script -}}
 script
 {{- else if .Sleep -}}

--- a/testdata/e2e/examples/patch/README.md
+++ b/testdata/e2e/examples/patch/README.md
@@ -17,5 +17,5 @@
 | # | Operation | Description |
 |:-:|---|---|
 | 1 | `apply` | *No description* |
-| 2 | `` | *No description* |
+| 2 | `patch` | *No description* |
 | 3 | `assert` | *No description* |


### PR DESCRIPTION
## Explanation

Add missing operations in build docs.
