### PR TITLE
fix(report): report path and prevent double extension on file name

### DIFF
--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -2,7 +2,6 @@
 
 Release notes for `TODO`.
 
-<!--
 ## ‼️ Breaking changes ‼️
 
 ## 💫 New features 💫
@@ -15,7 +14,10 @@ Release notes for `TODO`.
 
 ## 🔧 Fixes 🔧
 
+- Fixed report-path not being used in the `report`.
+- Prevent double extension in the `report` output file.
+
 ## 📚 Docs 📚
 
 ## 🎸 Misc 🎸
--->
+

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -136,15 +136,12 @@ func (report *TestsReport) SaveReportBasedOnType(reportFormat v1alpha1.ReportFor
 	if err != nil {
 		return err
 	}
-	var fileName string
-	if filepath.Ext(reportName) != "" {
-		fileName = reportName
-	} else {
-		fileName = reportName + "." + strings.ToLower(string(reportFormat))
+	if filepath.Ext(reportName) == "" {
+		reportName += "." + strings.ToLower(string(reportFormat))
 	}
-	filePath := fileName
-	if reportPath != "" {
-		filepath.Join(reportPath, fileName)
+	filePath := filepath.Join(reportPath, reportName)
+	if reportPath == "" {
+		filePath = reportName
 	}
 	return SaveReport(report, serializer, filePath)
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -136,7 +136,12 @@ func (report *TestsReport) SaveReportBasedOnType(reportFormat v1alpha1.ReportFor
 	if err != nil {
 		return err
 	}
-	fileName := reportName + "." + strings.ToLower(string(reportFormat))
+	var fileName string
+	if filepath.Ext(reportName) != "" {
+		fileName = reportName
+	} else {
+		fileName = reportName + "." + strings.ToLower(string(reportFormat))
+	}
 	filePath := fileName
 	if reportPath != "" {
 		filepath.Join(reportPath, fileName)

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -139,9 +139,9 @@ func (report *TestsReport) SaveReportBasedOnType(reportFormat v1alpha1.ReportFor
 	if filepath.Ext(reportName) == "" {
 		reportName += "." + strings.ToLower(string(reportFormat))
 	}
-	filePath := filepath.Join(reportPath, reportName)
-	if reportPath == "" {
-		filePath = reportName
+	filePath := reportName
+	if reportPath != "" {
+		filePath = filepath.Join(reportPath, reportName)
 	}
 	return SaveReport(report, serializer, filePath)
 }


### PR DESCRIPTION
Signed-off-by: Shubham Gupta <iamshubhamgupta2001@gmail.com>

## Explanation

don't put  double extension on a filename

## Related issue
Fixes https://github.com/kyverno/chainsaw/issues/930

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

**nNOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.

-->


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->