### PR TITLE
fix: base image for ko in goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,7 @@ builds:
 
 kos:
   - build: chainsaw
+    base_image: cgr.dev/chainguard/kubectl:latest-dev
     repository: ghcr.io/kyverno/chainsaw
     tags:
       - '{{.Tag}}'


### PR DESCRIPTION
## Explanation

Fix base image for ko in goreleaser config.

Potential fix for #821 
