### PR TITLE
feat: introduce lazy operations

### DIFF
--- a/pkg/runner/kubectl/describe.go
+++ b/pkg/runner/kubectl/describe.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 
 	"github.com/kyverno/chainsaw/pkg/apis/v1alpha1"
+	"github.com/kyverno/chainsaw/pkg/client"
 )
 
-func Describe(collector *v1alpha1.Describe) (*v1alpha1.Command, error) {
+func Describe(client client.Client, collector *v1alpha1.Describe) (*v1alpha1.Command, error) {
 	if collector == nil {
 		return nil, errors.New("collector is null")
 	}

--- a/pkg/runner/processors/cleaner_test.go
+++ b/pkg/runner/processors/cleaner_test.go
@@ -20,32 +20,25 @@ func Test_Cleaner_Register(t *testing.T) {
 		timeout    time.Duration
 		expectedOp int
 	}
-
-	testCases := []registerTestCase{
-		{
-			name:       "With 5 seconds timeout",
-			timeout:    5 * time.Second,
-			expectedOp: 1,
-		},
-		{
-			name:       "With 10 seconds timeout",
-			timeout:    10 * time.Second,
-			expectedOp: 2,
-		},
-	}
-
+	testCases := []registerTestCase{{
+		name:       "With 5 seconds timeout",
+		timeout:    5 * time.Second,
+		expectedOp: 1,
+	}, {
+		name:       "With 10 seconds timeout",
+		timeout:    10 * time.Second,
+		expectedOp: 2,
+	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeClient := &fake.FakeClient{}
 			mockObj := unstructured.Unstructured{}
 			fakeNamespacer := namespacer.New(fakeClient, "default")
-
 			c := newCleaner(fakeNamespacer, nil)
 			for i := 0; i < tc.expectedOp; i++ {
 				localTimeout := tc.timeout
 				c.register(mockObj, fakeClient, &localTimeout)
 			}
-
 			assert.Len(t, c.operations, tc.expectedOp)
 			for _, op := range c.operations {
 				assert.Equal(t, true, op.continueOnError)
@@ -61,26 +54,25 @@ func Test_Cleaner_Run(t *testing.T) {
 		namespacer namespacer.Namespacer
 		delay      *metav1.Duration
 		operations []operation
-	}{
-		{
-			name: "With 5 seconds delay",
-			delay: &metav1.Duration{
-				Duration: 5 * time.Second,
-			},
-			operations: []operation{
-				{
-					continueOnError: true,
-					timeout:         nil,
-					operation: mock.MockOperation{
-						ExecFn: func(_ context.Context, _ binding.Bindings) error {
-							return nil
-						},
-					},
-					operationReport: nil,
-				},
-			},
+	}{{
+		name: "With 5 seconds delay",
+		delay: &metav1.Duration{
+			Duration: 5 * time.Second,
 		},
-	}
+		operations: []operation{
+			newOperation(
+				true,
+				nil,
+				mock.MockOperation{
+					ExecFn: func(_ context.Context, _ binding.Bindings) error {
+						return nil
+					},
+				},
+				nil,
+				nil,
+			),
+		},
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &cleaner{

--- a/pkg/runner/processors/operation_test.go
+++ b/pkg/runner/processors/operation_test.go
@@ -21,56 +21,51 @@ func TestOperation_Execute(t *testing.T) {
 		operation       operations.Operation
 		operationReport *report.OperationReport
 		timeout         time.Duration
-	}{
-		{
-			name: "operation fails but continues",
-			operation: mock.MockOperation{
-				ExecFn: func(_ context.Context, _ binding.Bindings) error {
-					return errors.New("operation failed")
-				},
+	}{{
+		name: "operation fails but continues",
+		operation: mock.MockOperation{
+			ExecFn: func(_ context.Context, _ binding.Bindings) error {
+				return errors.New("operation failed")
 			},
-			continueOnError: true,
-			expectedFail:    true,
-			timeout:         1 * time.Second,
-			operationReport: report.NewOperation("FakeOperation", report.OperationTypeCreate),
 		},
-		{
-			name: "operation fails and don't continues",
-			operation: mock.MockOperation{
-				ExecFn: func(_ context.Context, _ binding.Bindings) error {
-					return errors.New("operation failed")
-				},
+		continueOnError: true,
+		expectedFail:    true,
+		timeout:         1 * time.Second,
+		operationReport: report.NewOperation("FakeOperation", report.OperationTypeCreate),
+	}, {
+		name: "operation fails and don't continues",
+		operation: mock.MockOperation{
+			ExecFn: func(_ context.Context, _ binding.Bindings) error {
+				return errors.New("operation failed")
 			},
-			continueOnError: false,
-			expectedFail:    true,
-			operationReport: report.NewOperation("FakeOperation", report.OperationTypeCreate),
 		},
-		{
-			name: "operation succeeds",
-			operation: mock.MockOperation{
-				ExecFn: func(_ context.Context, _ binding.Bindings) error {
-					return nil
-				},
+		continueOnError: false,
+		expectedFail:    true,
+		operationReport: report.NewOperation("FakeOperation", report.OperationTypeCreate),
+	}, {
+		name: "operation succeeds",
+		operation: mock.MockOperation{
+			ExecFn: func(_ context.Context, _ binding.Bindings) error {
+				return nil
 			},
-			expectedFail:    false,
-			timeout:         1 * time.Second,
-			operationReport: report.NewOperation("FakeOperation", report.OperationTypeCreate),
 		},
-	}
-
+		expectedFail:    false,
+		timeout:         1 * time.Second,
+		operationReport: report.NewOperation("FakeOperation", report.OperationTypeCreate),
+	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			localTC := tc
-			op := operation{
-				continueOnError: localTC.continueOnError,
-				timeout:         &localTC.timeout,
-				operation:       localTC.operation,
-				operationReport: localTC.operationReport,
-			}
+			op := newOperation(
+				localTC.continueOnError,
+				&localTC.timeout,
+				localTC.operation,
+				localTC.operationReport,
+				nil,
+			)
 			nt := testing.MockT{}
 			ctx := testing.IntoContext(context.Background(), &nt)
 			op.execute(ctx)
-
 			if localTC.expectedFail {
 				assert.True(t, nt.FailedVar, "expected an error but got none")
 			} else {


### PR DESCRIPTION
## Explanation

Introduce lazy operations.
This is needed when the content of the operation itself cannot be determined until it should execute.