### PR TITLE
fix: add missing operations in build docs command and support test level catch

### DIFF
--- a/pkg/commands/build/docs/docs.tmpl
+++ b/pkg/commands/build/docs/docs.tmpl
@@ -17,42 +17,58 @@ patch
 script
 {{- else if .Sleep -}}
 sleep
+{{- else if .Wait -}}
+wait
+{{- else -}}
+{{ fail (print "unknown operation " (toJson .)) }}
 {{- end -}}
 {{- end -}}
 
 {{- define "CatchType" -}}
 {{- if .Command -}}
 command
-{{- else if .Events -}}
-events
-{{- else if .PodLogs -}}
-pod logs
+{{- else if .Delete -}}
+delete
 {{- else if .Describe -}}
 describe
+{{- else if .Events -}}
+events
 {{- else if .Get -}}
 get
+{{- else if .PodLogs -}}
+pod logs
 {{- else if .Script -}}
 script
 {{- else if .Sleep -}}
 sleep
+{{- else if .Wait -}}
+wait
+{{- else -}}
+{{ fail (print "unknown catch " (toJson .)) }}
 {{- end -}}
 {{- end -}}
 
 {{- define "FinallyType" -}}
 {{- if .Command -}}
 command
-{{- else if .Events -}}
-events
-{{- else if .PodLogs -}}
-pod logs
+{{- else if .Delete -}}
+delete
 {{- else if .Describe -}}
 describe
+{{- else if .Events -}}
+events
 {{- else if .Get -}}
 get
+{{- else if .PodLogs -}}
+pod logs
 {{- else if .Script -}}
 script
 {{- else if .Sleep -}}
 sleep
+{{- else if .Wait -}}
+wait
+{{- else -}}
+{{ fail (print "unknown finally " (toJson .)) }}
 {{- end -}}
 {{- end -}}
 
@@ -68,7 +84,7 @@ sleep
 |:-:|---|:-:|:-:|:-:|
 {{- range $i, $step := . }}
 {{- $name := default (print "step-" (add $i 1)) $step.Name }}
-| {{ add $i 1 }} | [{{ $name }}](#step-{{ $name }}) | {{ len $step.Try }} | {{ len $step.Catch }} | {{ len $step.Finally }} |
+| {{ add $i 1 }} | [{{ $name }}](#step-{{ $name }}) | {{ len $step.Try }} | {{ add (len $step.Catch) (len $.Spec.Catch) }} | {{ len $step.Finally }} |
 {{- end }}
 {{- end }}
 
@@ -96,8 +112,11 @@ sleep
 
 | # | Operation | Description |
 |:-:|---|---|
-{{- range $i, $op := . }}
+{{- range $i, $op := $.Spec.Catch }}
 | {{ add $i 1 }} | `{{ template "CatchType" $op }}` | {{ default "*No description*" $op.Description }} |
+{{- end }}
+{{- range $i, $op := . }}
+| {{ add (len $.Spec.Catch) $i 1 }} | `{{ template "CatchType" $op }}` | {{ default "*No description*" $op.Description }} |
 {{- end }}
 {{- end }}
 

--- a/testdata/e2e/examples/wait/README.md
+++ b/testdata/e2e/examples/wait/README.md
@@ -6,7 +6,7 @@
 
 | # | Name | Try | Catch | Finally |
 |:-:|---|:-:|:-:|:-:|
-| 1 | [step-1](#step-step-1) | 4 | 2 | 2 |
+| 1 | [step-1](#step-step-1) | 4 | 4 | 2 |
 
 ## Step: `step-1`
 
@@ -17,20 +17,22 @@
 | # | Operation | Description |
 |:-:|---|---|
 | 1 | `create` | *No description* |
-| 2 | `` | *No description* |
+| 2 | `wait` | *No description* |
 | 3 | `delete` | *No description* |
-| 4 | `` | *No description* |
+| 4 | `wait` | *No description* |
 
 ### Catch
 
 | # | Operation | Description |
 |:-:|---|---|
-| 1 | `` | *No description* |
-| 2 | `` | *No description* |
+| 1 | `events` | *No description* |
+| 2 | `describe` | *No description* |
+| 3 | `delete` | *No description* |
+| 4 | `wait` | *No description* |
 
 ### Finally
 
 | # | Operation | Description |
 |:-:|---|---|
-| 1 | `` | *No description* |
-| 2 | `` | *No description* |
+| 1 | `delete` | *No description* |
+| 2 | `wait` | *No description* |

--- a/testdata/e2e/examples/wait/chainsaw-test.yaml
+++ b/testdata/e2e/examples/wait/chainsaw-test.yaml
@@ -4,6 +4,10 @@ kind: Test
 metadata:
   name: wait
 spec:
+  catch:
+  - events: {}
+  - describe:
+      resource: crds
   steps:
   - try:
     - create:


### PR DESCRIPTION
## Explanation

Add missing operations in build docs command and support test level catch.
