### PR TITLE
fix: test level bindings evaluated too early

### DIFF
--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -29,6 +29,7 @@ Release notes for `TODO`.
 ## 🔧 Fixes 🔧
 
 - Fixed a resource templating issue in non-resource assertions
+- Fixed test level bindings evaluated too early, potentially failing to resolve `$namespace` dependency
 - Fixed resource templating always enabled in `create` operation, regardless of the configured `template` field
 - Fixed resource templating always enabled in `patch` operation, regardless of the configured `template` field
 - Added missing operations to the `build docs` command template

--- a/pkg/runner/bindings/bindings.go
+++ b/pkg/runner/bindings/bindings.go
@@ -56,12 +56,19 @@ func RegisterBinding(ctx context.Context, bindings binding.Bindings, input any, 
 	return RegisterNamedBinding(ctx, bindings, name, value), nil
 }
 
-func RegisterBindings(ctx context.Context, bindings binding.Bindings, config *rest.Config, client client.Client, variables ...v1alpha1.Binding) (binding.Bindings, error) {
+func RegisterClusterBindings(ctx context.Context, bindings binding.Bindings, config *rest.Config, client client.Client) binding.Bindings {
 	if bindings == nil {
 		bindings = binding.NewBindings()
 	}
 	bindings = bindings.Register("$client", binding.NewBinding(client))
 	bindings = bindings.Register("$config", binding.NewBinding(config))
+	return bindings
+}
+
+func RegisterBindings(ctx context.Context, bindings binding.Bindings, variables ...v1alpha1.Binding) (binding.Bindings, error) {
+	if bindings == nil {
+		bindings = binding.NewBindings()
+	}
 	for _, variable := range variables {
 		next, err := RegisterBinding(ctx, bindings, nil, variable)
 		if err != nil {

--- a/pkg/runner/processors/operation.go
+++ b/pkg/runner/processors/operation.go
@@ -91,9 +91,10 @@ func (o operation) execute(ctx context.Context, bindings binding.Bindings) opera
 		}
 	}
 	operation, err := o.operation(ctx, bindings)
+	bindings = apibindings.RegisterClusterBindings(ctx, bindings, o.config, o.client)
 	if err != nil {
 		handleError(err)
-	} else if bindings, err := apibindings.RegisterBindings(ctx, bindings, o.config, o.client, o.variables...); err != nil {
+	} else if bindings, err := apibindings.RegisterBindings(ctx, bindings, o.variables...); err != nil {
 		handleError(err)
 	} else {
 		outputs, err := operation.Exec(ctx, apibindings.RegisterNamedBinding(ctx, bindings, "operation", o.info))

--- a/pkg/runner/processors/step.go
+++ b/pkg/runner/processors/step.go
@@ -86,7 +86,8 @@ func (p *stepProcessor) Run(ctx context.Context, bindings binding.Bindings) {
 	t := testing.FromContext(ctx)
 	logger := logging.FromContext(ctx)
 	config, cluster := p.clusters.client(p.step.Cluster, p.test.Spec.Cluster)
-	bindings, err := apibindings.RegisterBindings(ctx, bindings, config, cluster, p.step.Bindings...)
+	bindings = apibindings.RegisterClusterBindings(ctx, bindings, config, cluster)
+	bindings, err := apibindings.RegisterBindings(ctx, bindings, p.step.Bindings...)
 	if err != nil {
 		logging.Log(ctx, logging.Internal, logging.ErrorStatus, color.BoldRed, logging.ErrSection(err))
 		t.FailNow()

--- a/pkg/runner/processors/test.go
+++ b/pkg/runner/processors/test.go
@@ -110,11 +110,7 @@ func (p *testProcessor) Run(ctx context.Context, bindings binding.Bindings, nspa
 		}
 	}
 	config, cluster := p.clusters.client(p.test.Spec.Cluster)
-	bindings, err := apibindings.RegisterBindings(ctx, bindings, config, cluster, p.test.Spec.Bindings...)
-	if err != nil {
-		logging.Log(ctx, logging.Internal, logging.ErrorStatus, color.BoldRed, logging.ErrSection(err))
-		t.FailNow()
-	}
+	bindings = apibindings.RegisterClusterBindings(ctx, bindings, config, cluster)
 	setupLogger := logging.NewLogger(t, p.clock, p.test.Name, fmt.Sprintf("%-*s", size, "@setup"))
 	cleanupLogger := logging.NewLogger(t, p.clock, p.test.Name, fmt.Sprintf("%-*s", size, "@cleanup"))
 	var namespace *corev1.Namespace
@@ -170,6 +166,11 @@ func (p *testProcessor) Run(ctx context.Context, bindings binding.Bindings, nspa
 				}
 			}
 		}
+	}
+	bindings, err := apibindings.RegisterBindings(ctx, bindings, p.test.Spec.Bindings...)
+	if err != nil {
+		logging.Log(ctx, logging.Internal, logging.ErrorStatus, color.BoldRed, logging.ErrSection(err))
+		t.FailNow()
 	}
 	delay := p.config.DelayBeforeCleanup
 	if p.test.Spec.DelayBeforeCleanup != nil {

--- a/pkg/runner/processors/tests.go
+++ b/pkg/runner/processors/tests.go
@@ -70,11 +70,7 @@ func (p *testsProcessor) Run(ctx context.Context, bindings binding.Bindings) {
 	})
 	var nspacer namespacer.Namespacer
 	config, cluster := p.clusters.client()
-	bindings, err := apibindings.RegisterBindings(ctx, bindings, config, cluster)
-	if err != nil {
-		logging.Log(ctx, logging.Internal, logging.ErrorStatus, color.BoldRed, logging.ErrSection(err))
-		t.FailNow()
-	}
+	bindings = apibindings.RegisterClusterBindings(ctx, bindings, config, cluster)
 	if cluster != nil {
 		if p.config.Namespace != "" {
 			namespace := client.Namespace(p.config.Namespace)
@@ -117,6 +113,11 @@ func (p *testsProcessor) Run(ctx context.Context, bindings binding.Bindings) {
 				}
 			}
 		}
+	}
+	bindings, err := apibindings.RegisterBindings(ctx, bindings)
+	if err != nil {
+		logging.Log(ctx, logging.Internal, logging.ErrorStatus, color.BoldRed, logging.ErrSection(err))
+		t.FailNow()
 	}
 	for i, test := range p.tests {
 		name, err := names.Test(p.config, test)

--- a/testdata/e2e/examples/template/chainsaw-test.yaml
+++ b/testdata/e2e/examples/template/chainsaw-test.yaml
@@ -5,6 +5,9 @@ metadata:
   name: template
 spec:
   template: true
+  bindings:
+  - name: foo
+    value: (join('-', [$namespace, 'foo']))
   steps:
   - try:
     - apply:
@@ -12,15 +15,15 @@ spec:
           apiVersion: v1
           kind: ConfigMap
           metadata:
-            name: ($namespace)
+            name: ($foo)
     - assert:
         resource:
           apiVersion: v1
           kind: ConfigMap
           metadata:
-            name: ($namespace)
+            name: ($foo)
     - delete:
         ref:
           apiVersion: v1
           kind: ConfigMap
-          name: ($namespace)
+          name: ($foo)


### PR DESCRIPTION
## Explanation

Fix test level bindings evaluated too early.

See https://github.com/linode/cluster-api-provider-linode/pull/181