### PR TITLE
fix: relax step file discovery regexp

### DIFF
--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -36,6 +36,7 @@ Release notes for `TODO`.
 - Added test-level catch statements to the `build docs` command template
 - Added binding `name` validation markers
 - Fixed `build docs` command for files with multiple tests
+- Relaxed step file discovery regular expression to allow names with one or more digit prefixes
 
 ## ⭐ Examples ⭐
 

--- a/pkg/discovery/step.go
+++ b/pkg/discovery/step.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 )
 
-var StepFileName = regexp.MustCompile(`^(\d\d)-(.*)\.(?:yaml|yml)$`)
+var StepFileName = regexp.MustCompile(`^(\d+)-(.*)\.(?:yaml|yml)$`)
 
 type Step struct {
 	AssertFiles []string


### PR DESCRIPTION
## Explanation

Relax step file discovery regexp to allow more than 2 digits.
