### PR TITLE
chore: add json_parse to match in Outputs docs

### DIFF
--- a/website/docs/bindings/outputs.md
+++ b/website/docs/bindings/outputs.md
@@ -39,8 +39,9 @@ The json output is then parsed and added to the `$cm` binding and the next opera
             content: kubectl get cm quick-start -n $NAMESPACE -o json
             outputs:
             - match:
-                apiVersion: v1
-                kind: ConfigMap
+                (json_parse($stdout)):
+                  apiVersion: v1
+                  kind: ConfigMap
               name: cm
               value: (json_parse($stdout))
         - assert:
@@ -74,8 +75,9 @@ The json output is then parsed and added to the `$cm` binding and the next opera
             - json
             outputs:
             - match:
-                apiVersion: v1
-                kind: ConfigMap
+                (json_parse($stdout)):
+                  apiVersion: v1
+                  kind: ConfigMap
               name: cm
               value: (json_parse($stdout))
         - assert:


### PR DESCRIPTION
## Explanation

This PR updates the documentation to correctly demonstrate how to parse JSON outputs for bindings, ensuring users implement the syntax accurately by using json_parse($stdout) for command outputs.

## Related issue

Slack link: [here](https://kubernetes.slack.com/archives/C067LUFL43U/p1710497221445859)

## Proposed Changes

Enhancing the docs.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
