### PR TITLE
chore: add missing adopters to the home page

### DIFF
--- a/website/docs/overrides/home.html
+++ b/website/docs/overrides/home.html
@@ -197,7 +197,8 @@
 <div style="display: flex; flex-direction: column;">
 	<section class="tx-container tx-main-container">
 		<div class="md-grid md-typeset" style="min-height: inherit;">
-			<div class="tx-hero" style="display: flex; flex-direction: column; justify-content: center; min-height: inherit;">
+			<div class="tx-hero"
+				style="display: flex; flex-direction: column; justify-content: center; min-height: inherit;">
 				<div style="display: flex; justify-content: space-between; align-items: center;">
 					<div>
 						<h1>Kyverno Chainsaw</h1>
@@ -233,7 +234,8 @@
 			</div>
 		</div>
 	</section>
-	<section id="everything-you-would-expect" class="md-container tx-container" data-md-color-scheme="slate" style="min-height: 100vh;">
+	<section id="everything-you-would-expect" class="md-container tx-container" data-md-color-scheme="slate"
+		style="min-height: 100vh;">
 		<div class="md-content md-grid" data-md-component="content">
 			<div class="md-content__inner">
 				<header class="md-typeset">
@@ -344,25 +346,17 @@
 				</header>
 				<div class="grid">
 					<div class="card" style="display: flex; flex-direction: column;">
-						<p class="repo-card" data-repo="grafana/tempo-operator"></p>
-						<hr>
-						<cite>
-							Chainsaw cranked up the tempo, making our e2e tests dance to a rhythm of reliability and
-							efficiency.
-						</cite>
-					</div>
-					<div class="card" style="display: flex; flex-direction: column;">
-						<p class="repo-card" data-repo="keptn/lifecycle-toolkit"></p>
-						<hr>
-						<cite>
-							Chainsaw replaced Kuttl, and helped us get rid of many unreadable bash scripts.
-						</cite>
-					</div>
-					<div class="card" style="display: flex; flex-direction: column;">
 						<p class="repo-card" data-repo="kyverno/kyverno"></p>
 						<hr>
 						<cite>
 							Running all end to end tests for both Kyverno and the policies catalog.
+						</cite>
+					</div>
+					<div class="card" style="display: flex; flex-direction: column;">
+						<p class="repo-card" data-repo="fairwindsops/rbac-manager"></p>
+						<hr>
+						<cite>
+							Chainsaw replaced and improved upon our bash test framework for testing the RbacDefinition CRD.
 						</cite>
 					</div>
 					<div class="card" style="display: flex; flex-direction: column;">
@@ -373,10 +367,10 @@
 						</cite>
 					</div>
 					<div class="card" style="display: flex; flex-direction: column;">
-						<p class="repo-card" data-repo="linode/cluster-api-provider-linode"></p>
+						<p class="repo-card" data-repo="grafana/grafana-operator"></p>
 						<hr>
 						<cite>
-							Chainsaw replaced Kuttl and made our e2e tests much more readable and easier to debug.
+							Chainsaw enabled easier e2e testing and CI debugging after replacing kuttl.
 						</cite>
 					</div>
 					<div class="card" style="display: flex; flex-direction: column;">
@@ -385,6 +379,35 @@
 						<cite>
 							Chainsaw helped a lot for declarative assertion of Redis Cluster state against various e2e
 							test.
+						</cite>
+					</div>
+					<div class="card" style="display: flex; flex-direction: column;">
+						<p class="repo-card" data-repo="keptn/lifecycle-toolkit"></p>
+						<hr>
+						<cite>
+							Chainsaw replaced Kuttl, and helped us get rid of many unreadable bash scripts.
+						</cite>
+					</div>
+					<div class="card" style="display: flex; flex-direction: column;">
+						<p class="repo-card" data-repo="grafana/tempo-operator"></p>
+						<hr>
+						<cite>
+							Chainsaw cranked up the tempo, making our e2e tests dance to a rhythm of reliability and
+							efficiency.
+						</cite>
+					</div>
+					<div class="card" style="display: flex; flex-direction: column;">
+						<p class="repo-card" data-repo="linode/cluster-api-provider-linode"></p>
+						<hr>
+						<cite>
+							Chainsaw replaced Kuttl and made our e2e tests much more readable and easier to debug.
+						</cite>
+					</div>
+					<div class="card" style="display: flex; flex-direction: column;">
+						<p class="repo-card" data-repo="linode/provider-ceph"></p>
+						<hr>
+						<cite>
+							Chainsaw replaced Kuttl and made our e2e tests much more readable and easier to debug.
 						</cite>
 					</div>
 				</div>


### PR DESCRIPTION
## Explanation

Add missing adopters to the home page.

## Related issue

Fixes #1309 
