### PR TITLE
docs: fixed broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Built under the Kyverno umbrella, you can use the Kyverno Chainsaw **Slack chann
 
 ## Getting Started
 
-Please refer to the [Getting Started](https://kyverno.github.io/chainsaw/latest/intro/) documentation.
+Please refer to the [Getting Started](https://kyverno.github.io/chainsaw/latest/quick-start/) documentation.
 
 ## RoadMap
 


### PR DESCRIPTION
## Explanation

The `Getting Started` link in README is broken.

## Related issue


## Proposed Changes


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments
