### PR TITLE
fix: yaml anchors processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ tests: $(CLI_BIN)
 e2e-tests: ## Run e2e tests
 e2e-tests: $(CLI_BIN)
 	@echo Running e2e tests... >&2
-	@./$(CLI_BIN) test --test-dir ./testdata/e2e --config ./testdata/e2e/config-v1alpha2.yaml --values ./testdata/e2e/values.yaml
+	@./$(CLI_BIN) test --test-dir ./testdata/e2e --remarshal --config ./testdata/e2e/config-v1alpha2.yaml --values ./testdata/e2e/values.yaml
 
 .PHONY: e2e-tests-ko 
 e2e-tests-ko: ## Run e2e tests from a docker container
@@ -315,7 +315,7 @@ e2e-tests-ko: build-ko
 		--user $(id -u):$(id -g) \
 		--name chainsaw \
 		--rm \
-		ko.local/github.com/kyverno/chainsaw:$(KO_TAGS) test /chainsaw --config /chainsaw/config-v1alpha2.yaml --values /chainsaw/values.yaml --selector !no-ko-test
+		ko.local/github.com/kyverno/chainsaw:$(KO_TAGS) test /chainsaw --remarshal --config /chainsaw/config-v1alpha2.yaml --values /chainsaw/values.yaml --selector !no-ko-test
 
 ########	
 # KIND #

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.uber.org/multierr v1.11.0
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.4
 	k8s.io/apimachinery v0.29.4
 	k8s.io/client-go v0.29.4
@@ -138,7 +139,6 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.3 // indirect
 	k8s.io/apiserver v0.29.3 // indirect
 	k8s.io/component-base v0.29.3 // indirect

--- a/pkg/commands/build/docs/command.go
+++ b/pkg/commands/build/docs/command.go
@@ -40,7 +40,7 @@ func Command() *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			tests, err := discovery.DiscoverTests(options.testFile, nil, options.testDirs...)
+			tests, err := discovery.DiscoverTests(options.testFile, nil, true, options.testDirs...)
 			if err != nil {
 				return err
 			}

--- a/pkg/commands/test/command.go
+++ b/pkg/commands/test/command.go
@@ -63,6 +63,7 @@ type options struct {
 	pauseOnFailure              bool
 	values                      []string
 	clusters                    []string
+	remarshal                   bool
 }
 
 func Command() *cobra.Command {
@@ -251,6 +252,9 @@ func Command() *cobra.Command {
 			if len(configuration.Spec.Clusters) != 0 {
 				fmt.Fprintf(out, "- Clusters %v\n", configuration.Spec.Clusters)
 			}
+			if options.remarshal {
+				fmt.Fprintf(out, "- Remarshal %v\n", options.remarshal)
+			}
 			fmt.Fprintf(out, "- NoCluster %v\n", options.noCluster)
 			fmt.Fprintf(out, "- PauseOnFailure %v\n", options.pauseOnFailure)
 			// loading tests
@@ -266,7 +270,7 @@ func Command() *cobra.Command {
 				}
 				selector = parsed
 			}
-			tests, err := discovery.DiscoverTests(configuration.Spec.TestFile, selector, options.testDirs...)
+			tests, err := discovery.DiscoverTests(configuration.Spec.TestFile, selector, options.remarshal, options.testDirs...)
 			if err != nil {
 				return err
 			}
@@ -361,6 +365,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringSliceVar(&options.values, "values", nil, "Values passed to the tests")
 	// others
 	cmd.Flags().BoolVar(&options.noColor, "no-color", false, "Removes output colors")
+	cmd.Flags().BoolVar(&options.remarshal, "remarshal", false, "Remarshals tests yaml to apply anchors before parsing")
 	if err := cmd.MarkFlagFilename("config"); err != nil {
 		panic(err)
 	}

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -5,21 +5,21 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func DiscoverTests(fileName string, selector labels.Selector, paths ...string) ([]Test, error) {
+func DiscoverTests(fileName string, selector labels.Selector, remarshal bool, paths ...string) ([]Test, error) {
 	folders, err := fsutils.DiscoverFolders(paths...)
 	if err != nil {
 		return nil, err
 	}
-	return discoverTests(fileName, selector, folders...)
+	return discoverTests(fileName, selector, remarshal, folders...)
 }
 
-func discoverTests(fileName string, selector labels.Selector, folders ...string) ([]Test, error) {
+func discoverTests(fileName string, selector labels.Selector, remarshal bool, folders ...string) ([]Test, error) {
 	if selector == nil {
 		selector = labels.Everything()
 	}
 	var tests []Test
 	for _, folder := range folders {
-		t, err := LoadTest(fileName, folder)
+		t, err := LoadTest(fileName, folder, remarshal)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -114,7 +114,7 @@ func TestDiscoverTests(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := DiscoverTests(tt.fileName, nil, tt.paths...)
+			got, err := DiscoverTests(tt.fileName, nil, false, tt.paths...)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -145,7 +145,7 @@ func TestHelpDiscoverTests(t *testing.T) {
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tests, err := discoverTests("chainsaw-test.yaml", nil, tc.folders...)
+			tests, err := discoverTests("chainsaw-test.yaml", nil, false, tc.folders...)
 			if tc.expectError {
 				assert.Error(t, err, "Expected an error but got none")
 			} else {
@@ -162,6 +162,6 @@ func TestDiscoverTests_UnreadableFolder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to change directory permissions: %v", err)
 	}
-	_, err = DiscoverTests("chainsaw-test.yaml", nil, tempDir)
+	_, err = DiscoverTests("chainsaw-test.yaml", nil, false, tempDir)
 	assert.Error(t, err, "Expected an error for unreadable folder")
 }

--- a/pkg/discovery/load.go
+++ b/pkg/discovery/load.go
@@ -14,42 +14,42 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func tryLoadTestFile(file string) ([]*v1alpha1.Test, error) {
+func tryLoadTestFile(file string, remarshal bool) ([]*v1alpha1.Test, error) {
 	if _, err := os.Stat(file); err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	tests, err := test.Load(file)
+	tests, err := test.Load(file, remarshal)
 	if err != nil {
 		return nil, err
 	}
 	return tests, nil
 }
 
-func tryLoadTestFiles(fileName string, path string) ([]*v1alpha1.Test, error) {
+func tryLoadTestFiles(fileName string, path string, remarshal bool) ([]*v1alpha1.Test, error) {
 	if filepath.Ext(fileName) != "" {
-		return tryLoadTestFile(filepath.Join(path, fileName))
+		return tryLoadTestFile(filepath.Join(path, fileName), remarshal)
 	}
-	tests, err := tryLoadTestFile(filepath.Join(path, fileName+".yaml"))
+	tests, err := tryLoadTestFile(filepath.Join(path, fileName+".yaml"), remarshal)
 	if err != nil {
 		return nil, err
 	}
 	if tests != nil {
 		return tests, nil
 	}
-	return tryLoadTestFile(filepath.Join(path, fileName+".yml"))
+	return tryLoadTestFile(filepath.Join(path, fileName+".yml"), remarshal)
 }
 
-func LoadTest(fileName string, path string) ([]Test, error) {
+func LoadTest(fileName string, path string, remarshal bool) ([]Test, error) {
 	// first, try to load a test manifest
 	if path == "" {
 		return nil, errors.New("path must be specified")
 	}
 	var tests []Test
 	if fileName != "" {
-		apiTests, err := tryLoadTestFiles(fileName, path)
+		apiTests, err := tryLoadTestFiles(fileName, path, remarshal)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/discovery/load_test.go
+++ b/pkg/discovery/load_test.go
@@ -322,7 +322,7 @@ func TestLoadTest(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadTest(tt.fileName, tt.path)
+			got, err := LoadTest(tt.fileName, tt.path, false)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -345,6 +345,6 @@ func Test_tryLoadTest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to change file permissions: %v", err)
 	}
-	_, err = tryLoadTestFile(filePath)
+	_, err = tryLoadTestFile(filePath, false)
 	assert.Error(t, err)
 }

--- a/pkg/test/load.go
+++ b/pkg/test/load.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/kyverno/chainsaw/pkg/apis/v1alpha1"
 	internalloader "github.com/kyverno/chainsaw/pkg/internal/loader"
+	yamlutils "github.com/kyverno/chainsaw/pkg/utils/yaml"
 	testvalidation "github.com/kyverno/chainsaw/pkg/validation/test"
 	"github.com/kyverno/pkg/ext/resource/convert"
 	"github.com/kyverno/pkg/ext/resource/loader"
 	"github.com/kyverno/pkg/ext/yaml"
-	yamlv3 "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/openapi"
@@ -26,12 +26,12 @@ type (
 
 var test_v1alpha1 = v1alpha1.SchemeGroupVersion.WithKind("Test")
 
-func Load(path string) ([]*v1alpha1.Test, error) {
+func Load(path string, remarshal bool) ([]*v1alpha1.Test, error) {
 	content, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}
-	tests, err := Parse(content)
+	tests, err := Parse(content, remarshal)
 	if err != nil {
 		return nil, err
 	}
@@ -41,20 +41,11 @@ func Load(path string) ([]*v1alpha1.Test, error) {
 	return tests, nil
 }
 
-func Parse(content []byte) ([]*v1alpha1.Test, error) {
-	return parse(content, nil, nil, nil, nil)
+func Parse(content []byte, remarshal bool) ([]*v1alpha1.Test, error) {
+	return parse(content, remarshal, nil, nil, nil, nil)
 }
 
-func remarshal(document []byte) ([]byte, error) {
-	var pre map[string]any
-	err := yamlv3.Unmarshal(document, &pre)
-	if err != nil {
-		return nil, err
-	}
-	return yamlv3.Marshal(pre)
-}
-
-func parse(content []byte, splitter splitter, loaderFactory loaderFactory, converter converter, validator validator) ([]*v1alpha1.Test, error) {
+func parse(content []byte, remarshal bool, splitter splitter, loaderFactory loaderFactory, converter converter, validator validator) ([]*v1alpha1.Test, error) {
 	if splitter == nil {
 		splitter = yaml.SplitDocuments
 	}
@@ -84,9 +75,12 @@ func parse(content []byte, splitter splitter, loaderFactory loaderFactory, conve
 	}
 	var tests []*v1alpha1.Test
 	for _, document := range documents {
-		document, err := remarshal(document)
-		if err != nil {
-			return nil, err
+		if remarshal {
+			altered, err := yamlutils.Remarshal(document)
+			if err != nil {
+				return nil, err
+			}
+			document = altered
 		}
 		gvk, untyped, err := loader.Load(document)
 		if err != nil {

--- a/pkg/test/load_test.go
+++ b/pkg/test/load_test.go
@@ -203,7 +203,7 @@ func TestLoad(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Load(tt.path)
+			got, err := Load(tt.path, false)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -280,7 +280,7 @@ func Test_parse(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := parse(content, tt.splitter, tt.loaderFactory, tt.converter, tt.validator)
+			_, err := parse(content, false, tt.splitter, tt.loaderFactory, tt.converter, tt.validator)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -295,7 +295,7 @@ func Test_parse_globalErr(t *testing.T) {
 	assert.NoError(t, err)
 	internalloader.Err = errors.New("dummy error")
 	{
-		_, err := parse(content, nil, nil, nil, nil)
+		_, err := parse(content, false, nil, nil, nil, nil)
 		assert.Error(t, err)
 	}
 }

--- a/pkg/utils/yaml/yaml.go
+++ b/pkg/utils/yaml/yaml.go
@@ -1,0 +1,14 @@
+package yaml
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+func Remarshal(document []byte) ([]byte, error) {
+	var pre map[string]any
+	err := yaml.Unmarshal(document, &pre)
+	if err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(pre)
+}

--- a/testdata/commands/test/help.txt
+++ b/testdata/commands/test/help.txt
@@ -44,6 +44,7 @@ Flags:
       --no-color                                  Removes output colors
       --parallel int                              The maximum number of tests to run at once
       --pause-on-failure                          Pause test execution failure (implies no concurrency)
+      --remarshal                                 Remarshals tests yaml to apply anchors before parsing
       --repeat-count int                          Number of times to repeat each test (default 1)
       --report-format string                      Test report format (JSON|XML|nil)
       --report-name string                        The name of the report to create (default "chainsaw-report")

--- a/testdata/e2e/examples/CATALOG.md
+++ b/testdata/e2e/examples/CATALOG.md
@@ -33,3 +33,4 @@
 - [update-crd](update-crd/README.md)
 - [values](values/README.md)
 - [wait](wait/README.md)
+- [yaml-anchors](yaml-anchors/README.md)

--- a/testdata/e2e/examples/yaml-anchors/README.md
+++ b/testdata/e2e/examples/yaml-anchors/README.md
@@ -1,0 +1,23 @@
+# Test: `yaml-anchors`
+
+*No description*
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|
+| 1 | [yaml-anchors](#step-yaml-anchors) | 0 | 2 | 0 | 0 | 0 |
+
+### Step: `yaml-anchors`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+---
+

--- a/testdata/e2e/examples/yaml-anchors/chainsaw-test.yaml
+++ b/testdata/e2e/examples/yaml-anchors/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: &name yaml-anchors
+spec:
+  namespace: &namespace default
+  steps:
+  - name: *name
+    try:
+    - apply:
+        resource: &resource
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: *name
+            namespace: *namespace
+          spec:
+            containers:
+            - name: main
+              image: alpine
+    - assert:
+        resource:
+          <<: *resource
+          spec:
+            restartPolicy: Always
+        timeout: 1s

--- a/website/docs/reference/commands/chainsaw_test.md
+++ b/website/docs/reference/commands/chainsaw_test.md
@@ -49,6 +49,7 @@ chainsaw test [flags]... [test directories]...
       --no-color                                  Removes output colors
       --parallel int                              The maximum number of tests to run at once
       --pause-on-failure                          Pause test execution failure (implies no concurrency)
+      --remarshal                                 Remarshals tests yaml to apply anchors before parsing
       --repeat-count int                          Number of times to repeat each test (default 1)
       --report-format string                      Test report format (JSON|XML|nil)
       --report-name string                        The name of the report to create (default "chainsaw-report")


### PR DESCRIPTION
## Explanation

Fix yaml anchors processing.
At first sight [gopkg.in/yaml.v3](http://gopkg.in/yaml.v3) looks more correct, at least in this area :thinking_face:

## Related issue

Fixes #1275 
