### PR TITLE
fix: write report in format json

### DIFF
--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -1,0 +1,14 @@
+package report
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func saveJson(report *Report, file string) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(file, data, 0o600)
+}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -66,10 +66,10 @@ func (r *Report) Save(format v1alpha1.ReportFormatType, path, name string) error
 	case v1alpha1.XMLFormat:
 		return saveJUnit(r, filePath)
 	case v1alpha1.JSONFormat:
+		return saveJson(r, filePath)
 	default:
 		return fmt.Errorf("unknown report format: %s", format)
 	}
-	return nil
 }
 
 type TestReport struct {


### PR DESCRIPTION
## Explanation

This PR's goal is to fix a bug that came up in `v0.2.0` where reports are not being created when using a format of type `JSON`.

## Related issue

https://github.com/kyverno/chainsaw/issues/1537

## Proposed Changes

It looks like in https://github.com/kyverno/chainsaw/pull/1190 that the JSON report type support was removed but the case still exists. This just re-implements the old logic.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

There are existing tests which declare a type of `JSON` in their formatter and so there is "coverage" but the error state of the JSON failing to marshal is not tested.