### PR TITLE
fix: xml report structure fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-getter v1.7.4
 	github.com/jmespath-community/go-jmespath v1.1.2-0.20240117150817-e430401a2172
+	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/kudobuilder/kuttl v0.16.0
 	github.com/kyverno/kyverno-json v0.0.3
 	github.com/kyverno/pkg/ext v0.0.0-20240418121121-df8add26c55c

--- a/go.sum
+++ b/go.sum
@@ -462,6 +462,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
+github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/report/junit.go
+++ b/pkg/report/junit.go
@@ -3,119 +3,96 @@ package report
 import (
 	"encoding/xml"
 	"fmt"
+	"github.com/jstemmer/go-junit-report/v2/junit"
 	"os"
 	"time"
 )
 
-type failureNode struct {
-	XMLName struct{} `xml:"failure"`
+const (
+	FailureTypeAssertionError = "AssertionError"
+)
+
+// durationInSecondsString is a helper function to convert a start and end time into a string
+// representing the duration in seconds. This is needed by the junit package for generating
+// the JUnit XML report.
+func durationInSecondsString(start, end time.Time) string {
+	duration := end.Sub(start)
+	return fmt.Sprintf("%.6f", duration.Seconds())
 }
 
-type skippedNode struct {
-	XMLName struct{} `xml:"skipped"`
-}
-
-type propertyNode struct {
-	XMLName struct{} `xml:"property"`
-	Name    string   `xml:"name,attr"`
-	Value   string   `xml:"value,attr,omitempty"`
-}
-
-type propertiesNode struct {
-	XMLName struct{} `xml:"properties"`
-	Inner   []any
-}
-
-type testcaseNode struct {
-	XMLName   struct{} `xml:"testcase"`
-	Name      string   `xml:"name,attr,omitempty"`
-	Timestamp string   `xml:"timestamp,attr,omitempty"`
-	Time      float64  `xml:"time,attr,omitempty"`
-	File      string   `xml:"file,attr,omitempty"`
-	Inner     []any
-}
-
-type testsuiteNode struct {
-	XMLName   struct{} `xml:"testsuite"`
-	Name      string   `xml:"name,attr,omitempty"`
-	Timestamp string   `xml:"timestamp,attr,omitempty"`
-	File      string   `xml:"file,attr,omitempty"`
-	Inner     []any
-}
-
-type testsuitesNode struct {
-	XMLName   struct{} `xml:"testsuites"`
-	Name      string   `xml:"name,attr,omitempty"`
-	Timestamp string   `xml:"timestamp,attr,omitempty"`
-	Time      float64  `xml:"time,attr,omitempty"`
-	Inner     []any
-}
-
-func saveJUnit(report *Report, file string) error {
-	testsuites := testsuitesNode{
-		Name:      report.name,
-		Timestamp: report.startTime.UTC().Format(time.RFC3339),
-		Time:      report.endTime.Sub(report.startTime).Seconds(),
-	}
-	perFolder := map[string][]*TestReport{}
+// addTestSuite loops through all the operations reports for each directory that is
+// being tested and adds them to the JUnit XML report. This is done by looping through
+// all tests and then looping through all of their steps and all the reports for all steps.
+//
+// The end goal is to have each Test file represented as a TestSuite and each step as a TestCase.
+func addTestSuite(testSuites *junit.Testsuites, report *Report) {
+	// Loop through all the Tests in the report
 	for _, test := range report.tests {
-		perFolder[test.test.BasePath] = append(perFolder[test.test.BasePath], test)
-	}
-	for folder, tests := range perFolder {
-		testsuite := testsuiteNode{
-			Name: folder,
+		// Initialize the TestSuite for this test
+		suite := junit.Testsuite{
+			Name:      test.test.Name,                              // Name is pulled args to the command (--report-name)
+			Timestamp: report.startTime.UTC().Format(time.RFC3339), // Take the time from the beginning of the test
+			Time:      durationInSecondsString(test.startTime, test.endTime),
 		}
-		for _, test := range tests {
-			var properties []any
-			if test.namespace != "" {
-				properties = append(properties, propertyNode{
-					Name:  "namespace",
-					Value: test.namespace,
-				})
-			}
-			for i, step := range test.steps {
-				if step.step.Name != "" {
-					properties = append(properties, propertyNode{
-						Name:  fmt.Sprintf("step%d", i),
-						Value: step.step.Name,
-					})
+
+		// Loop through all the Steps in the Test
+		for _, step := range test.steps {
+			// Loop through each Report
+			for _, report := range step.reports {
+				// Each report is now an individual Testcase because it is a single operation executed
+				// against a cluster and can fail on its own.
+				testCase := junit.Testcase{
+					Name:      report.name,
+					Classname: suite.Name, // Associate the Testcase with the TestSuite
+					Time:      durationInSecondsString(report.startTime, report.endTime),
 				}
-				for j, op := range step.reports {
-					if op.err != nil {
-						properties = append(properties, propertyNode{
-							Name:  fmt.Sprintf("step%d", i),
-							Value: fmt.Sprintf("op %d - %s: %s", j, op.operationType, op.err),
-						})
-					} else {
-						properties = append(properties, propertyNode{
-							Name:  fmt.Sprintf("step%d", i),
-							Value: fmt.Sprintf("op %d - %s", j, op.operationType),
-						})
+
+				// Each report will have an error property set if the step failed.
+				if report.err != nil {
+					testCase.Failure = &junit.Result{
+						Message: report.err.Error(),
+					}
+
+					// Type hints can help identify what the error was. This is not required but can be helpful.
+					// TODO: add more type hints
+					// https://github.com/testmoapp/junitxml?tab=readme-ov-file#conventions-types
+					switch report.operationType {
+					case OperationTypeAssert:
+						testCase.Failure.Type = FailureTypeAssertionError
+					default:
+						testCase.Failure.Type = "" // Do not set if we don't know what to categorize it as
 					}
 				}
+
+				// Add each Testcase to the parent suite in order to increment the count of failures/successes/etc.
+				suite.AddTestcase(testCase)
 			}
-			testcase := testcaseNode{
-				Name:      test.test.Name,
-				Timestamp: test.startTime.UTC().Format(time.RFC3339),
-				Time:      test.endTime.Sub(test.startTime).Seconds(),
-				File:      test.test.BasePath,
-			}
-			if len(properties) != 0 {
-				testcase.Inner = append(testcase.Inner, propertiesNode{Inner: properties})
-			}
-			if test.skipped {
-				testcase.Inner = append(testcase.Inner, skippedNode{})
-			}
-			if test.failed {
-				testcase.Inner = append(testcase.Inner, failureNode{})
-			}
-			testsuite.Inner = append(testsuite.Inner, testcase)
 		}
-		testsuites.Inner = append(testsuites.Inner, testsuite)
+
+		// Add the test suite to the parent
+		testSuites.AddSuite(suite)
 	}
-	data, err := xml.MarshalIndent(testsuites, "", "  ")
+}
+
+// saveJUnit writes the JUnit XML report to disk. The spec is defined here:
+// https://github.com/testmoapp/junitxml
+//
+// This method makes use of https://github.com/jstemmer/go-junit-report to generate the XML.
+func saveJUnit(report *Report, file string) error {
+	// Initialize the top-level TestSuites object
+	testSuites := &junit.Testsuites{
+		Name:   report.name,
+		Time:   durationInSecondsString(report.startTime, report.endTime),
+		Suites: []junit.Testsuite{},
+	}
+
+	// Append the individual test suites to the parent
+	addTestSuite(testSuites, report)
+
+	data, err := xml.MarshalIndent(testSuites, "", "  ")
 	if err != nil {
 		return err
 	}
+
 	return os.WriteFile(file, data, 0o600)
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -150,3 +150,8 @@ func (r *OperationReport) SetStartTime(t time.Time) {
 func (r *OperationReport) SetEndTime(t time.Time) {
 	r.endTime = t
 }
+
+// Fail marks the operation as failed by assigning the `err` property
+func (r *OperationReport) Fail(err error) {
+	r.err = err
+}

--- a/pkg/runner/processors/operation.go
+++ b/pkg/runner/processors/operation.go
@@ -75,6 +75,11 @@ func (o operation) execute(ctx context.Context, bindings binding.Bindings) opera
 		// 	o.operationReport.MarkOperationEnd(err)
 		// }
 		if err != nil {
+			// Capture the error of the execution for the report here. Not done in `handleError` because `nil` is
+			// explicitly passed to the handler to not trigger a duplicate log line.
+			if o.report != nil {
+				o.report.Fail(err)
+			}
 			handleError(nil)
 		}
 		return outputs


### PR DESCRIPTION
## Explanation

In https://github.com/kyverno/chainsaw/issues/1537 I started looking into error reporting from `chainsaw` to use in some other tooling. I ended up finding that errors from individual steps were not being captured and surfaced in the current XML report generation.

This PR aims to do two things that can be divided into separate PRs:

- Ensure errors are captured in the Report steps (https://github.com/kyverno/chainsaw/commit/e901bae5f119e8f4ffd467ef512afc4bc7ca7f3a)
- Move XML generation logic to `jstemmer/go-junit-report` (https://github.com/kyverno/chainsaw/commit/1ac0dce8276f80a1fa91872607e530e83adffb09)

I think there can be arguments made for restructuring some of this around and not using an external lib, but this was a quick way to get closer to the JUnit examples defined here: https://github.com/testmoapp/junitxml

## Related issue

https://github.com/kyverno/chainsaw/issues/1537


## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

**nNOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.

-->

To break this down a bit we're going to need to look at a test with a failure. To make this simple we're going to take the [`basic` e2e test data](https://github.com/kyverno/chainsaw/tree/main/testdata/e2e/examples/basic) and amend it to look like the following:

```yaml
v1alpha1.json
apiVersion: chainsaw.kyverno.io/v1alpha1
kind: Test
metadata:
  name: basic
spec:
  description: This is a very simple test that creates a configmap and checks the content is as expected.
  steps:
  - description: This steps applies the configmap in the cluster and checks the configmap content.
    try:
    - description: Create the configmap.
      apply:
        file: configmap.yaml
    - description: Check the configmap content.
      assert:
        file: configmap-assert.yaml
    - script:
        content: cd .. && kubectl get pod -A
    - assert:
        resource:
          apiVersion: v1
          kind: Deployment
          metadata:
            name: foo
          spec:
            (replicas > 3): true
```

This will 100% fail since we're not defining the `Deployment` at all.

### Report Before Changes
```xml
<testsuites name="test-report" timestamp="2024-06-09T20:18:43Z" time="5.459461875">
  <testsuite name="testdata/e2e/examples/basic">
    <testcase name="basic" timestamp="2024-06-09T20:18:43Z" time="5.459016791" file="testdata/e2e/examples/basic">
      <properties>
        <property name="namespace" value="chainsaw-grateful-vervet"></property>
        <property name="step0" value="op 0 - apply"></property>
        <property name="step0" value="op 1 - assert"></property>
        <property name="step0" value="op 2 - script"></property>
        <property name="step0" value="op 3 - assert"></property>
      </properties>
      <failure></failure>
    </testcase>
  </testsuite>
</testsuites>
```

When comparing this to the [examples found here](https://github.com/testmoapp/junitxml), I found the following issues:

- The failure condition is not captured
- The entire test is a single test case, which doesn't allow for discreet errors to be captured
- The metadata of `errors`/`failures`/`tests`/etc. is not captured on the `testsuite`

### After The Change

```xml
<testsuites name="test-report" time="5.367257" tests="4" failures="1">
  <testsuite name="basic" tests="4" failures="1" errors="0" id="0" time="5.366757" timestamp="2024-06-09T20:19:22Z">
    <testcase name="Apply configmap.yaml" classname="basic" time="0.073743"></testcase>
    <testcase name="Assert " classname="basic" time="0.060858"></testcase>
    <testcase name="Script " classname="basic" time="0.068323"></testcase>
    <testcase name="Assert " classname="basic" time="0.011395">
      <failure message="failed to get restmapping: no matches for kind &#34;Deployment&#34; in group &#34;&#34;" type="AssertionError"></failure>
    </testcase>
  </testsuite>
</testsuites>
```

There are still some things I'm not happy with:

- The package used doesn't support `properties` at the `testcase` level
- There is still some checking to be added for `type` on failures

But the main improvements are:

- Errors are better captured
- The output is more in line with the spec
- We could render this same struct to JSON and support the JSON output option (but also might require a little cleanup)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

I'd like to refine this a bit more if the direction seems solid, but would like to get input first before continuing