### PR TITLE
fix: parameter cleanup delay in docs

### DIFF
--- a/website/docs/configuration/options/cleanup.md
+++ b/website/docs/configuration/options/cleanup.md
@@ -35,5 +35,5 @@ spec:
 ```bash
 chainsaw test                   \
   --skip-delete                 \
-  --delay-before-cleanup 5s
+  --cleanup-delay 5s
 ```


### PR DESCRIPTION

## Explanation

The command in the docs doesn't exist, replaced by the correct one: `cleanup-delay`.

## Related issue

na

## Proposed Changes

small docs change


## Checklist


- [ x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments
