### PR TITLE
fix: use absolute path in command and script for KUBECONFIG

### DIFF
--- a/pkg/engine/operations/command/operation.go
+++ b/pkg/engine/operations/command/operation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/jmespath-community/go-jmespath/pkg/binding"
 	"github.com/kyverno/chainsaw/pkg/apis/v1alpha1"
@@ -73,7 +74,7 @@ func (o *operation) createCommand(ctx context.Context, bindings binding.Bindings
 		if err != nil {
 			return nil, nil, err
 		}
-		path := f.Name()
+		path := filepath.Join(o.basePath, f.Name())
 		cancel = func() {
 			err := os.Remove(path)
 			if err != nil {

--- a/pkg/engine/operations/script/operation.go
+++ b/pkg/engine/operations/script/operation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/jmespath-community/go-jmespath/pkg/binding"
 	"github.com/kyverno/chainsaw/pkg/apis/v1alpha1"
@@ -72,7 +73,7 @@ func (o *operation) createCommand(ctx context.Context, bindings binding.Bindings
 		if err != nil {
 			return nil, nil, err
 		}
-		path := f.Name()
+		path := filepath.Join(o.basePath, f.Name())
 		cancel = func() {
 			err := os.Remove(path)
 			if err != nil {


### PR DESCRIPTION
## Explanation

Use absolute path in command and script for `KUBECONFIG`.
