### PR TITLE
fix: step template bindings wrong order

### DIFF
--- a/pkg/discovery/load.go
+++ b/pkg/discovery/load.go
@@ -67,8 +67,8 @@ func LoadTest(fileName string, path string, remarshal bool) ([]Test, error) {
 							return nil, errors.New("step template not found or multiple templates exist")
 						}
 						template := steptpl[0]
-						step.Bindings = append(step.Bindings, step.Use.With.Bindings...)
 						step.Bindings = append(step.Bindings, template.Spec.Bindings...)
+						step.Bindings = append(step.Bindings, step.Use.With.Bindings...)
 						step.Try = append(step.Try, template.Spec.Try...)
 						step.Catch = append(step.Catch, template.Spec.Catch...)
 						step.Finally = append(step.Finally, template.Spec.Finally...)

--- a/testdata/e2e/examples/CATALOG.md
+++ b/testdata/e2e/examples/CATALOG.md
@@ -34,6 +34,7 @@
 - [script-env](script-env/README.md)
 - [sleep](sleep/README.md)
 - [quick-start](step-template/README.md)
+- [step-template-bindings](step-template-bindings/README.md)
 - [template](template/README.md)
 - [test-info](test-info/README.md)
 - [timeout](timeout/README.md)

--- a/testdata/e2e/examples/step-template-bindings/README.md
+++ b/testdata/e2e/examples/step-template-bindings/README.md
@@ -1,0 +1,40 @@
+# Test: `step-template-bindings`
+
+*No description*
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [step-1](#step-step-1) | 2 | 1 | 0 | 0 | 0 |
+| 2 | [step-2](#step-step-2) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `step-1`
+
+*No description*
+
+#### Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `input` | "from-template" |
+| 2 | `input` | "from-test" |
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `step-2`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+

--- a/testdata/e2e/examples/step-template-bindings/chainsaw-test.yaml
+++ b/testdata/e2e/examples/step-template-bindings/chainsaw-test.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=../../../../.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: step-template-bindings
+spec:
+  steps:
+  - use:
+      template: template.yaml
+      with:
+        bindings:
+        - name: input
+          value: from-test
+  - try:
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: from-test

--- a/testdata/e2e/examples/step-template-bindings/template.yaml
+++ b/testdata/e2e/examples/step-template-bindings/template.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../../../../.schemas/json/steptemplate-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: template
+spec:
+  bindings:
+  - name: input
+    value: from-template
+  try:
+  - create:
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ($input)


### PR DESCRIPTION
## Explanation

Fix step template bindings registered in  wrong order.

## Related issue

Fixes https://github.com/kyverno/chainsaw/issues/2133
