### PR TITLE
docs: fix grammatical issue in README Community Meetings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To attend our community meetings, join the [Chainsaw group](https://groups.googl
 You will then be sent a meeting invite and will have access to the agenda and meeting notes.
 Any member may suggest topics for discussion.
 
-This is a public, weekly for Kyverno-Chainsaw maintainers to make announcements and provide project updates, and request input and feedback.
+This is a public, weekly meeting for Kyverno-Chainsaw maintainers to make announcements and provide project updates, and request input and feedback.
 This forum allows community members to raise agenda items of any sort, including but not limited to any PRs or issues on which they are working.
 
 Weekly every Thursday at 2:00 PM UTC


### PR DESCRIPTION
## Explanation

This PR fixes a grammatical issue in the README.md file. In the Community Meetings section, there was a missing word that made the sentence unclear. The text "This is a public, weekly for Kyverno-Chainsaw maintainers..." has been corrected to "This is a public, weekly meeting for Kyverno-Chainsaw maintainers..." which improves readability and clarity of the documentation.

## Related issue

This is a minor documentation improvement that enhances readability. No specific issue is being fixed, but it contributes to the overall documentation quality.

## Proposed Changes

- Fixed the grammatical issue in the README.md file by adding the missing word "meeting" in the Community Meetings section description

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

Signed-off-by: Karthik babu Manam <karthikmanam@gmail.com>