### PR TITLE
docs: Do not use pipes in comments, they won't be rendered in Markdown tables

### DIFF
--- a/.crds/chainsaw.kyverno.io_configurations.yaml
+++ b/.crds/chainsaw.kyverno.io_configurations.yaml
@@ -902,7 +902,7 @@ spec:
                 type: integer
               reportFormat:
                 description: |-
-                  ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION|nil) nil == no report.
+                  ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION, nil) nil == no report.
                   maps to report.Type, however we don't want generated.deepcopy to have reference to it.
                 enum:
                 - JSON
@@ -1899,7 +1899,8 @@ spec:
                 properties:
                   format:
                     default: JSON
-                    description: ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION).
+                    description: ReportFormat determines test report format (JSON,
+                      XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION).
                     enum:
                     - JSON
                     - XML

--- a/.schemas/json/configuration-chainsaw-v1alpha1.json
+++ b/.schemas/json/configuration-chainsaw-v1alpha1.json
@@ -1764,7 +1764,7 @@
           "minimum": 1
         },
         "reportFormat": {
-          "description": "ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION|nil) nil == no report.\nmaps to report.Type, however we don't want generated.deepcopy to have reference to it.",
+          "description": "ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION, nil) nil == no report.\nmaps to report.Type, however we don't want generated.deepcopy to have reference to it.",
           "type": [
             "string",
             "null"

--- a/.schemas/json/configuration-chainsaw-v1alpha2.json
+++ b/.schemas/json/configuration-chainsaw-v1alpha2.json
@@ -1841,7 +1841,7 @@
           ],
           "properties": {
             "format": {
-              "description": "ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION).",
+              "description": "ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION).",
               "type": [
                 "string",
                 "null"

--- a/pkg/apis/v1alpha1/configuration.go
+++ b/pkg/apis/v1alpha1/configuration.go
@@ -58,7 +58,7 @@ type ConfigurationSpec struct {
 	// +kubebuilder:default:=Background
 	DeletionPropagationPolicy metav1.DeletionPropagation `json:"deletionPropagationPolicy,omitempty"`
 
-	// ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION|nil) nil == no report.
+	// ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION/nil) nil == no report.
 	// maps to report.Type, however we don't want generated.deepcopy to have reference to it.
 	// +optional
 	// +kubebuilder:validation:Enum:=JSON;XML;JUNIT-TEST;JUNIT-STEP;JUNIT-OPERATION;

--- a/pkg/apis/v1alpha1/configuration.go
+++ b/pkg/apis/v1alpha1/configuration.go
@@ -58,7 +58,7 @@ type ConfigurationSpec struct {
 	// +kubebuilder:default:=Background
 	DeletionPropagationPolicy metav1.DeletionPropagation `json:"deletionPropagationPolicy,omitempty"`
 
-	// ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION/nil) nil == no report.
+	// ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION, nil) nil == no report.
 	// maps to report.Type, however we don't want generated.deepcopy to have reference to it.
 	// +optional
 	// +kubebuilder:validation:Enum:=JSON;XML;JUNIT-TEST;JUNIT-STEP;JUNIT-OPERATION;

--- a/pkg/apis/v1alpha2/options.go
+++ b/pkg/apis/v1alpha2/options.go
@@ -107,7 +107,7 @@ const (
 
 // ReportOptions contains the configuration used for reporting.
 type ReportOptions struct {
-	// ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION).
+	// ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION).
 	// +optional
 	// +kubebuilder:validation:Enum:=JSON;XML;JUNIT-TEST;JUNIT-STEP;JUNIT-OPERATION
 	// +kubebuilder:default:="JSON"

--- a/pkg/apis/v1alpha2/options.go
+++ b/pkg/apis/v1alpha2/options.go
@@ -107,7 +107,7 @@ const (
 
 // ReportOptions contains the configuration used for reporting.
 type ReportOptions struct {
-	// ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION).
+	// ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION).
 	// +optional
 	// +kubebuilder:validation:Enum:=JSON;XML;JUNIT-TEST;JUNIT-STEP;JUNIT-OPERATION
 	// +kubebuilder:default:="JSON"

--- a/pkg/commands/test/command.go
+++ b/pkg/commands/test/command.go
@@ -415,7 +415,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&options.deletionPropagationPolicy, "deletion-propagation-policy", "Background", "The deletion propagation policy (Foreground|Background|Orphan)")
 	// error options
 	// reporting options
-	cmd.Flags().StringVar(&options.reportFormat, "report-format", "", "Test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION)")
+	cmd.Flags().StringVar(&options.reportFormat, "report-format", "", "Test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION)")
 	cmd.Flags().StringVar(&options.reportName, "report-name", "chainsaw-report", "The name of the report to create")
 	cmd.Flags().StringVar(&options.reportPath, "report-path", "", "The path of the report to create")
 	// multi-cluster options

--- a/pkg/data/crds/chainsaw.kyverno.io_configurations.yaml
+++ b/pkg/data/crds/chainsaw.kyverno.io_configurations.yaml
@@ -902,7 +902,7 @@ spec:
                 type: integer
               reportFormat:
                 description: |-
-                  ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION|nil) nil == no report.
+                  ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION, nil) nil == no report.
                   maps to report.Type, however we don't want generated.deepcopy to have reference to it.
                 enum:
                 - JSON
@@ -1899,7 +1899,8 @@ spec:
                 properties:
                   format:
                     default: JSON
-                    description: ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION).
+                    description: ReportFormat determines test report format (JSON,
+                      XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION).
                     enum:
                     - JSON
                     - XML

--- a/pkg/data/schemas/json/configuration-chainsaw-v1alpha1.json
+++ b/pkg/data/schemas/json/configuration-chainsaw-v1alpha1.json
@@ -1764,7 +1764,7 @@
           "minimum": 1
         },
         "reportFormat": {
-          "description": "ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION|nil) nil == no report.\nmaps to report.Type, however we don't want generated.deepcopy to have reference to it.",
+          "description": "ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION, nil) nil == no report.\nmaps to report.Type, however we don't want generated.deepcopy to have reference to it.",
           "type": [
             "string",
             "null"

--- a/pkg/data/schemas/json/configuration-chainsaw-v1alpha2.json
+++ b/pkg/data/schemas/json/configuration-chainsaw-v1alpha2.json
@@ -1841,7 +1841,7 @@
           ],
           "properties": {
             "format": {
-              "description": "ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION).",
+              "description": "ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION).",
               "type": [
                 "string",
                 "null"

--- a/testdata/commands/test/help.txt
+++ b/testdata/commands/test/help.txt
@@ -47,7 +47,7 @@ Flags:
       --pause-on-failure                          Pause test execution failure (implies no concurrency)
       --remarshal                                 Remarshals tests yaml to apply anchors before parsing
       --repeat-count int                          Number of times to repeat each test (default 1)
-      --report-format string                      Test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION)
+      --report-format string                      Test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION)
       --report-name string                        The name of the report to create (default "chainsaw-report")
       --report-path string                        The path of the report to create
       --selector strings                          Selector (label query) to filter on

--- a/website/docs/configuration/options/report.md
+++ b/website/docs/configuration/options/report.md
@@ -6,7 +6,7 @@ Reporting options contain the configuration used by Chainsaw for reporting.
 
 | Element | Default | Description |
 |---|---|---|
-| `format` | `JSON` | ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION). |
+| `format` | `JSON` | ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION). |
 | `path` | | ReportPath defines the path. |
 | `name` | `chainsaw-report` | ReportName defines the name of report to create. It defaults to "chainsaw-report". |
 

--- a/website/docs/configuration/options/report.md
+++ b/website/docs/configuration/options/report.md
@@ -6,7 +6,7 @@ Reporting options contain the configuration used by Chainsaw for reporting.
 
 | Element | Default | Description |
 |---|---|---|
-| `format` | `JSON` | ReportFormat determines test report format (JSON|XML). |
+| `format` | `JSON` | ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION). |
 | `path` | | ReportPath defines the path. |
 | `name` | `chainsaw-report` | ReportName defines the name of report to create. It defaults to "chainsaw-report". |
 

--- a/website/docs/reference/apis/chainsaw.v1alpha1.md
+++ b/website/docs/reference/apis/chainsaw.v1alpha1.md
@@ -428,7 +428,7 @@ during the testing process.</p>
 | `failFast` | `bool` |  |  | <p>FailFast determines whether the test should stop upon encountering the first failure.</p> |
 | `parallel` | `int` |  |  | <p>The maximum number of tests to run at once.</p> |
 | `deletionPropagationPolicy` | [`meta/v1.DeletionPropagation`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#deletionpropagation-v1-meta) |  |  | <p>DeletionPropagationPolicy decides if a deletion will propagate to the dependents of the object, and how the garbage collector will handle the propagation.</p> |
-| `reportFormat` | [`ReportFormatType`](#chainsaw-kyverno-io-v1alpha1-ReportFormatType) |  |  | <p>ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION|nil) nil == no report. maps to report.Type, however we don't want generated.deepcopy to have reference to it.</p> |
+| `reportFormat` | [`ReportFormatType`](#chainsaw-kyverno-io-v1alpha1-ReportFormatType) |  |  | <p>ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION/nil) nil == no report. maps to report.Type, however we don't want generated.deepcopy to have reference to it.</p> |
 | `reportPath` | `string` |  |  | <p>ReportPath defines the path.</p> |
 | `reportName` | `string` |  |  | <p>ReportName defines the name of report to create. It defaults to "chainsaw-report".</p> |
 | `namespace` | `string` |  |  | <p>Namespace defines the namespace to use for tests. If not specified, every test will execute in a random ephemeral namespace unless the namespace is overridden in a the test spec.</p> |

--- a/website/docs/reference/apis/chainsaw.v1alpha1.md
+++ b/website/docs/reference/apis/chainsaw.v1alpha1.md
@@ -428,7 +428,7 @@ during the testing process.</p>
 | `failFast` | `bool` |  |  | <p>FailFast determines whether the test should stop upon encountering the first failure.</p> |
 | `parallel` | `int` |  |  | <p>The maximum number of tests to run at once.</p> |
 | `deletionPropagationPolicy` | [`meta/v1.DeletionPropagation`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#deletionpropagation-v1-meta) |  |  | <p>DeletionPropagationPolicy decides if a deletion will propagate to the dependents of the object, and how the garbage collector will handle the propagation.</p> |
-| `reportFormat` | [`ReportFormatType`](#chainsaw-kyverno-io-v1alpha1-ReportFormatType) |  |  | <p>ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION/nil) nil == no report. maps to report.Type, however we don't want generated.deepcopy to have reference to it.</p> |
+| `reportFormat` | [`ReportFormatType`](#chainsaw-kyverno-io-v1alpha1-ReportFormatType) |  |  | <p>ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION, nil) nil == no report. maps to report.Type, however we don't want generated.deepcopy to have reference to it.</p> |
 | `reportPath` | `string` |  |  | <p>ReportPath defines the path.</p> |
 | `reportName` | `string` |  |  | <p>ReportName defines the name of report to create. It defaults to "chainsaw-report".</p> |
 | `namespace` | `string` |  |  | <p>Namespace defines the namespace to use for tests. If not specified, every test will execute in a random ephemeral namespace unless the namespace is overridden in a the test spec.</p> |

--- a/website/docs/reference/apis/chainsaw.v1alpha2.md
+++ b/website/docs/reference/apis/chainsaw.v1alpha2.md
@@ -152,7 +152,7 @@ auto_generated: true
 
 | Field | Type | Required | Inline | Description |
 |---|---|---|---|---|
-| `format` | [`ReportFormatType`](#chainsaw-kyverno-io-v1alpha2-ReportFormatType) |  |  | <p>ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION).</p> |
+| `format` | [`ReportFormatType`](#chainsaw-kyverno-io-v1alpha2-ReportFormatType) |  |  | <p>ReportFormat determines test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION).</p> |
 | `path` | `string` |  |  | <p>ReportPath defines the path.</p> |
 | `name` | `string` |  |  | <p>ReportName defines the name of report to create. It defaults to "chainsaw-report".</p> |
 

--- a/website/docs/reference/apis/chainsaw.v1alpha2.md
+++ b/website/docs/reference/apis/chainsaw.v1alpha2.md
@@ -152,7 +152,7 @@ auto_generated: true
 
 | Field | Type | Required | Inline | Description |
 |---|---|---|---|---|
-| `format` | [`ReportFormatType`](#chainsaw-kyverno-io-v1alpha2-ReportFormatType) |  |  | <p>ReportFormat determines test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION).</p> |
+| `format` | [`ReportFormatType`](#chainsaw-kyverno-io-v1alpha2-ReportFormatType) |  |  | <p>ReportFormat determines test report format (JSON/XML/JUNIT-TEST/JUNIT-STEP/JUNIT-OPERATION).</p> |
 | `path` | `string` |  |  | <p>ReportPath defines the path.</p> |
 | `name` | `string` |  |  | <p>ReportName defines the name of report to create. It defaults to "chainsaw-report".</p> |
 

--- a/website/docs/reference/commands/chainsaw_test.md
+++ b/website/docs/reference/commands/chainsaw_test.md
@@ -52,7 +52,7 @@ chainsaw test [flags]... [test directories]...
       --pause-on-failure                          Pause test execution failure (implies no concurrency)
       --remarshal                                 Remarshals tests yaml to apply anchors before parsing
       --repeat-count int                          Number of times to repeat each test (default 1)
-      --report-format string                      Test report format (JSON|XML|JUNIT-TEST|JUNIT-STEP|JUNIT-OPERATION)
+      --report-format string                      Test report format (JSON, XML, JUNIT-TEST, JUNIT-STEP, JUNIT-OPERATION)
       --report-name string                        The name of the report to create (default "chainsaw-report")
       --report-path string                        The path of the report to create
       --selector strings                          Selector (label query) to filter on


### PR DESCRIPTION
## Explanation

There's a literal `JSON|XML...` in one comment, which then gets rendered in a Markdown table (which uses pipes for column separator) and all but the first element in this piped array is lost. See https://kyverno.github.io/chainsaw/0.2.3/configuration/options/report/ and https://kyverno.github.io/chainsaw/0.2.3/reference/apis/chainsaw.v1alpha2/#chainsaw-kyverno-io-v1alpha2-Report

## Related issue

None

## Proposed Changes

Swapping pipes for slashes, the implied meaning stays the same and we don't have to worry about rendering issues.

I ran `make codegen-api-docs` before submitting this change.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Supersedes #2350