### PR TITLE
Release docs with a regular release

### DIFF
--- a/.docs/RELEASE.md
+++ b/.docs/RELEASE.md
@@ -2,6 +2,14 @@
 
 This doc contains information for releasing a new version.
 
+## Release notes
+
+Release notes for the `main` branch live in [main.md](../../.release-notes/main.md).
+
+Make sure it is up to date and rename the file to the version being released.
+
+You can then copy [_template.md](../../.release-notes/_template.md) to [main.md](../../.release-notes/main.md) for the next release.
+
 ## Create a release
 
 Creating a release can be done by pushing a tag to the GitHub repository (beginning with `v`).
@@ -11,28 +19,6 @@ The [release workflow](../../.github/workflows/release.yaml) will take care of c
 ```shell
 VERSION="v0.1.0"
 TAG=$VERSION
-
-git tag $TAG -m "tag $TAG" -a
-git push origin $TAG
-```
-
-## Release notes
-
-Release notes for the `main` branch live in [main.md](../../.release-notes/main.md).
-
-Make sure it is up to date and rename the file to the version being released.
-
-You can then copy [_template.md](../../.release-notes/_template.md) to [main.md](../../.release-notes/main.md) for the next release.
-
-## Publish documentation
-
-Publishing the documentation for a release is decoupled from cutting a release.
-
-To publish the documentation push a tag to the GitHub repository (beginning with `docs-v`).
-
-```shell
-VERSION="v0.1.0"
-TAG=docs-$VERSION
 
 git tag $TAG -m "tag $TAG" -a
 git push origin $TAG

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -7,7 +7,7 @@ permissions: {}
 on:
   push:
     tags:
-      - docs-v*
+      - v*
 
 jobs:
   docs-release:
@@ -20,7 +20,7 @@ jobs:
         uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3 # v1.4.7
         with:
           input_string: ${{ github.ref_name }}
-          version_extractor_regex: '^docs-v(.*)$'
+          version_extractor_regex: '^v(.*)$'
       - name: Checkout
         if: ${{ steps.semver.outputs.prerelease == '' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Explanation

Currently docs for Chainsaw are released whenever a `docs-v*` tag is pushed. The last time this happens was with https://github.com/kyverno/chainsaw/releases/tag/docs-v0.2.3, nearly one year ago. Since then the newest features (e.g. StepTemplate) are only accessible in the "main" documentation.
This is not ideal, especially since the warning banner is telling reads to go to the """latest""" version v0.2.3
![image](https://github.com/user-attachments/assets/b4132197-01bc-4315-871b-a525976fdea2)

I suspect this is a process issue of the fact docs releases are decoupled from regular releases. Therefore this changes proposes to unify them.

## Related issue

#2373 


## Proposed Changes

This PR proposes a unified release process of release artefacts and documentation. This requires less mental effort when doing releases and no checklist besides creating a simple tag.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Please treat this as a propsal, my goal here is to start a discussion as I as an external maintainer won't handle releases myself.