### PR TITLE
chore(deps): bump golangci-lint to v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,6 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           skip-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "2"
 linters:
   enable:
     - asasalint
@@ -9,41 +10,45 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errname
-    - gci
     - gochecknoinits
-    - gofmt
-    - gofumpt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - makezero
     - misspell
     - noctx
     - nolintlint
     - nosprintfhostport
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
-    - unused
     - usetesting
     - wastedassign
     - whitespace
-
-run:
-  timeout: 15m
-
-output:
-  sort-results: true
-
-issues:
-  exclude-files:
-    - ".+\\.generated.go"
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - .+\.generated.go
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - .+\.generated.go
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/commands/docs/utils.go
+++ b/pkg/commands/docs/utils.go
@@ -19,7 +19,7 @@ func websitePrepender(filename string) string {
 	now := time.Now().Format(time.RFC3339)
 	name := filepath.Base(filename)
 	base := strings.TrimSuffix(name, path.Ext(name))
-	return fmt.Sprintf(fmTemplate, now, strings.Replace(base, "_", " ", -1))
+	return fmt.Sprintf(fmTemplate, now, strings.ReplaceAll(base, "_", " "))
 }
 
 func websiteLinkHandler(filename string) string {

--- a/pkg/commands/migrate/kuttl/tests/command.go
+++ b/pkg/commands/migrate/kuttl/tests/command.go
@@ -151,7 +151,7 @@ func processStep(stderr io.Writer, step *v1alpha1.TestStep, s discovery.Step, fo
 			}
 		}
 		if !containsKuttlResources {
-			step.TestStepSpec.Try = append(step.TestStepSpec.Try, v1alpha1.Operation{
+			step.Try = append(step.Try, v1alpha1.Operation{
 				Apply: &v1alpha1.Apply{
 					ActionResourceRef: v1alpha1.ActionResourceRef{
 						FileRef: v1alpha1.FileRef{
@@ -193,7 +193,7 @@ func processStep(stderr io.Writer, step *v1alpha1.TestStep, s discovery.Step, fo
 					return err
 				}
 			}
-			step.TestStepSpec.Try = append(step.TestStepSpec.Try, v1alpha1.Operation{
+			step.Try = append(step.Try, v1alpha1.Operation{
 				Apply: &v1alpha1.Apply{
 					ActionResourceRef: v1alpha1.ActionResourceRef{
 						FileRef: v1alpha1.FileRef{
@@ -218,7 +218,7 @@ func processStep(stderr io.Writer, step *v1alpha1.TestStep, s discovery.Step, fo
 			}
 		}
 		if !containsKuttlResources {
-			step.TestStepSpec.Try = append(step.TestStepSpec.Try, v1alpha1.Operation{
+			step.Try = append(step.Try, v1alpha1.Operation{
 				Assert: &v1alpha1.Assert{
 					ActionCheckRef: v1alpha1.ActionCheckRef{
 						FileRef: v1alpha1.FileRef{
@@ -254,7 +254,7 @@ func processStep(stderr io.Writer, step *v1alpha1.TestStep, s discovery.Step, fo
 					return err
 				}
 			}
-			step.TestStepSpec.Try = append(step.TestStepSpec.Try, v1alpha1.Operation{
+			step.Try = append(step.Try, v1alpha1.Operation{
 				Assert: &v1alpha1.Assert{
 					ActionCheckRef: v1alpha1.ActionCheckRef{
 						FileRef: v1alpha1.FileRef{
@@ -279,7 +279,7 @@ func processStep(stderr io.Writer, step *v1alpha1.TestStep, s discovery.Step, fo
 			}
 		}
 		if !containsKuttlResources {
-			step.TestStepSpec.Try = append(step.TestStepSpec.Try, v1alpha1.Operation{
+			step.Try = append(step.Try, v1alpha1.Operation{
 				Error: &v1alpha1.Error{
 					ActionCheckRef: v1alpha1.ActionCheckRef{
 						FileRef: v1alpha1.FileRef{
@@ -315,7 +315,7 @@ func processStep(stderr io.Writer, step *v1alpha1.TestStep, s discovery.Step, fo
 					return err
 				}
 			}
-			step.TestStepSpec.Try = append(step.TestStepSpec.Try, v1alpha1.Operation{
+			step.Try = append(step.Try, v1alpha1.Operation{
 				Error: &v1alpha1.Error{
 					ActionCheckRef: v1alpha1.ActionCheckRef{
 						FileRef: v1alpha1.FileRef{

--- a/pkg/discovery/load.go
+++ b/pkg/discovery/load.go
@@ -109,7 +109,7 @@ func LoadTest(fileName string, path string, remarshal bool) ([]Test, error) {
 			Name: fmt.Sprintf("step-%s", key),
 		}
 		for _, file := range steps[key].OtherFiles {
-			step.TestStepSpec.Try = append(step.TestStepSpec.Try, v1alpha1.Operation{
+			step.Try = append(step.Try, v1alpha1.Operation{
 				Apply: &v1alpha1.Apply{
 					ActionResourceRef: v1alpha1.ActionResourceRef{
 						FileRef: v1alpha1.FileRef{
@@ -120,7 +120,7 @@ func LoadTest(fileName string, path string, remarshal bool) ([]Test, error) {
 			})
 		}
 		for _, file := range steps[key].AssertFiles {
-			step.TestStepSpec.Try = append(step.TestStepSpec.Try, v1alpha1.Operation{
+			step.Try = append(step.Try, v1alpha1.Operation{
 				Assert: &v1alpha1.Assert{
 					ActionCheckRef: v1alpha1.ActionCheckRef{
 						FileRef: v1alpha1.FileRef{
@@ -131,7 +131,7 @@ func LoadTest(fileName string, path string, remarshal bool) ([]Test, error) {
 			})
 		}
 		for _, file := range steps[key].ErrorFiles {
-			step.TestStepSpec.Try = append(step.TestStepSpec.Try, v1alpha1.Operation{
+			step.Try = append(step.Try, v1alpha1.Operation{
 				Error: &v1alpha1.Error{
 					ActionCheckRef: v1alpha1.ActionCheckRef{
 						FileRef: v1alpha1.FileRef{

--- a/pkg/engine/kubectl/wait.go
+++ b/pkg/engine/kubectl/wait.go
@@ -39,18 +39,18 @@ func Wait(ctx context.Context, compilers compilers.Compilers, client client.Clie
 		return "", nil, err
 	}
 	args := []string{"wait", resource}
-	if collector.WaitFor.Deletion != nil {
+	if collector.Deletion != nil {
 		args = append(args, "--for=delete")
-	} else if collector.WaitFor.Condition != nil {
-		name, err := collector.WaitFor.Condition.Name.Value(ctx, compilers, tc)
+	} else if collector.Condition != nil {
+		name, err := collector.Condition.Name.Value(ctx, compilers, tc)
 		if err != nil {
 			return "", nil, err
 		}
 		if name == "" {
 			return "", nil, errors.New("a condition name must be specified for condition wait type")
 		}
-		if collector.WaitFor.Condition.Value != nil {
-			value, err := collector.WaitFor.Condition.Value.Value(ctx, compilers, tc)
+		if collector.Condition.Value != nil {
+			value, err := collector.Condition.Value.Value(ctx, compilers, tc)
 			if err != nil {
 				return "", nil, err
 			}
@@ -58,16 +58,16 @@ func Wait(ctx context.Context, compilers compilers.Compilers, client client.Clie
 		} else {
 			args = append(args, fmt.Sprintf("--for=condition=%s", name))
 		}
-	} else if collector.WaitFor.JsonPath != nil {
-		path, err := collector.WaitFor.JsonPath.Path.Value(ctx, compilers, tc)
+	} else if collector.JsonPath != nil {
+		path, err := collector.JsonPath.Path.Value(ctx, compilers, tc)
 		if err != nil {
 			return "", nil, err
 		}
 		if path == "" {
 			return "", nil, errors.New("a path must be specified for jsonpath wait type")
 		}
-		if collector.WaitFor.JsonPath.Value != nil {
-			value, err := collector.WaitFor.JsonPath.Value.Value(ctx, compilers, tc)
+		if collector.JsonPath.Value != nil {
+			value, err := collector.JsonPath.Value.Value(ctx, compilers, tc)
 			if err != nil {
 				return "", nil, err
 			}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -49,7 +49,7 @@ func (r *runner) Run(ctx context.Context, nsOptions v1alpha2.NamespaceOptions, t
 
 func (r *runner) run(ctx context.Context, m mainstart, nsOptions v1alpha2.NamespaceOptions, tc enginecontext.TestContext, tests ...discovery.Test) error {
 	defer func() {
-		tc.Report.EndTime = time.Now()
+		tc.EndTime = time.Now()
 	}()
 	// sanity check
 	if len(tests) == 0 {
@@ -134,7 +134,7 @@ func (r *runner) run(ctx context.Context, m mainstart, nsOptions v1alpha2.Namesp
 						defer func() {
 							report.EndTime = time.Now()
 							report.Skipped = t.Skipped()
-							tc.Report.Add(report)
+							tc.Add(report)
 						}()
 						// skip check
 						if test.Test.Spec.Skip != nil && *test.Test.Spec.Skip {

--- a/pkg/utils/rest/config.go
+++ b/pkg/utils/rest/config.go
@@ -64,8 +64,8 @@ func Save(cfg *rest.Config, w io.Writer) error {
 				Name: "chainsaw",
 				Cluster: api.Cluster{
 					Server:                   cfg.Host,
-					CertificateAuthorityData: cfg.TLSClientConfig.CAData,
-					InsecureSkipTLSVerify:    cfg.TLSClientConfig.Insecure,
+					CertificateAuthorityData: cfg.CAData,
+					InsecureSkipTLSVerify:    cfg.Insecure,
 				},
 			},
 		},
@@ -82,8 +82,8 @@ func Save(cfg *rest.Config, w io.Writer) error {
 			{
 				Name: "chainsaw",
 				AuthInfo: api.AuthInfo{
-					ClientCertificateData: cfg.TLSClientConfig.CertData,
-					ClientKeyData:         cfg.TLSClientConfig.KeyData,
+					ClientCertificateData: cfg.CertData,
+					ClientKeyData:         cfg.KeyData,
 					Token:                 cfg.BearerToken,
 					Username:              cfg.Username,
 					Password:              cfg.Password,


### PR DESCRIPTION
## Explanation

This updates golangci-lint to v2 to keep dependencies up to date and take advantage of updated linters. This will ensure that the code remains easy to consume and up to date with latest best practices per the various linters configured.

## Related issue
N/A

## Proposed Changes

Update golangci-lint from v1 syntax to v2 via `golangci-lint migrate` and address any lints that are picked up by updated linters.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

This is a pretty small change and can be confirmed by running `golangci-lint run -v ./...` where golangci-lint is of version `v2.X` and you can verify that there are no lints that need addressed.