### PR TITLE
chore: make kube 1.35 the default version

### DIFF
--- a/.release-notes/main.md
+++ b/.release-notes/main.md
@@ -5,6 +5,8 @@ Release notes for `TODO`.
 <!--
 ## ‼️ Breaking changes ‼️
 
+## 💫 New features 💫
+
 ## ✨ UI changes ✨
 
 ## ⭐ Examples ⭐
@@ -17,14 +19,3 @@ Release notes for `TODO`.
 
 ## 🎸 Misc 🎸
 -->
-
-## 💫 New features 💫
-
-- Added support for Kubernetes 1.34
-
-## 📚 Docs 📚
-
-- Added Scenarios documentation
-- Added Sharding documentation
-- Added StepTemplate documentation
-- Added other missing documentation bits

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LD_FLAGS                           := "-s -w"
 endif
 KO_REGISTRY                        := ko.local
 KO_TAGS                            := $(GIT_SHA)
-KIND_IMAGE                         ?= kindest/node:v1.34.0
+KIND_IMAGE                         ?= kindest/node:v1.35.0
 
 #########
 # TOOLS #


### PR DESCRIPTION
## Explanation

Make kube 1.35 the default version.
