### PR TITLE
fix: expose scenario name in $test binding

### DIFF
--- a/pkg/runner/info.go
+++ b/pkg/runner/info.go
@@ -5,9 +5,10 @@ import (
 )
 
 type TestInfo struct {
-	Id         int
-	ScenarioId int
-	Metadata   metav1.ObjectMeta
+	Id           int
+	ScenarioId   int
+	ScenarioName string
+	Metadata     metav1.ObjectMeta
 }
 
 type StepInfo struct {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -137,7 +137,7 @@ func (r *runner) run(ctx context.Context, m mainstart, nsOptions v1alpha2.Namesp
 							return
 						}
 						// setup context
-						tc, err := r.setupTestContext(ctx, testId, scenarioId, tc, test, bindings...)
+						tc, err := r.setupTestContext(ctx, testId, scenarioId, scenarioName, tc, test, bindings...)
 						if fail(t, err) {
 							return
 						}
@@ -516,11 +516,12 @@ func (r *runner) setupNamespace(ctx context.Context, nsOptions v1alpha2.Namespac
 	return tc, nil
 }
 
-func (r *runner) setupTestContext(ctx context.Context, testId int, scenarioId int, tc enginecontext.TestContext, test discovery.Test, bindings ...v1alpha1.Binding) (enginecontext.TestContext, error) {
+func (r *runner) setupTestContext(ctx context.Context, testId int, scenarioId int, scenarioName string, tc enginecontext.TestContext, test discovery.Test, bindings ...v1alpha1.Binding) (enginecontext.TestContext, error) {
 	tc = tc.WithBinding("test", TestInfo{
-		Id:         testId,
-		ScenarioId: scenarioId,
-		Metadata:   test.Test.ObjectMeta,
+		Id:           testId,
+		ScenarioId:   scenarioId,
+		ScenarioName: scenarioName,
+		Metadata:     test.Test.ObjectMeta,
 	})
 	tc, err := enginecontext.WithBindings(tc, bindings...)
 	if err != nil {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -417,6 +417,28 @@ func Test_runner_run(t *testing.T) {
 	}
 }
 
+func Test_runner_setupTestContext(t *testing.T) {
+	r := &runner{clock: clock.RealClock{}}
+	tc := enginecontext.EmptyContext(clock.RealClock{})
+	test := discovery.Test{
+		Test: &model.Test{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-test"},
+		},
+	}
+	got, err := r.setupTestContext(context.TODO(), 1, 2, "my-scenario", tc, test)
+	assert.NoError(t, err)
+	binding, err := got.Bindings().Get("$test")
+	assert.NoError(t, err)
+	val, err := binding.Value()
+	assert.NoError(t, err)
+	info, ok := val.(TestInfo)
+	assert.True(t, ok)
+	assert.Equal(t, 1, info.Id)
+	assert.Equal(t, 2, info.ScenarioId)
+	assert.Equal(t, "my-scenario", info.ScenarioName)
+	assert.Equal(t, "my-test", info.Metadata.Name)
+}
+
 func Test_runner_onFail(t *testing.T) {
 	{
 		r := &runner{


### PR DESCRIPTION
## Explanation

Scenario names were silently ignored at runtime - defining a `name` on a scenario had no effect beyond the YAML schema. This fix makes the name available as `$test.ScenarioName` so it can be referenced in bindings, scripts, and expressions.

## Related issue

Fixes #2614

## Proposed Changes

- Added `ScenarioName string` to `TestInfo` in `pkg/runner/info.go`
- Passed `scenarioName` into `setupTestContext` so it gets populated in the `$test` binding

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

Before this fix, `$test.ScenarioName` was always an empty string even when `name` was set on a scenario:
```json
{"Id":1,"ScenarioId":1,"ScenarioName":"","Metadata":{"name":"scenario-name-test"}}
