### PR TITLE
feat: extend status subresource patches via annotation

### DIFF
--- a/pkg/apis/v1alpha1/action.go
+++ b/pkg/apis/v1alpha1/action.go
@@ -262,6 +262,9 @@ type Get struct {
 
 // Patch represents a set of resources that should be patched.
 // If a resource doesn't exist yet in the cluster it will fail.
+// Subresources can be patched by adding the annotation "chainsaw.kyverno.io/patch-subresource",
+// where the value is the name of the subresource to be patched, to the resource. A subresource defined via
+// annotation wins against the subresource defined the Patch struct.
 type Patch struct {
 	ActionBindings     `json:",inline"`
 	ActionClusters     `json:",inline"`

--- a/pkg/client/testing/fake_client.go
+++ b/pkg/client/testing/fake_client.go
@@ -20,6 +20,7 @@ type FakeClient struct {
 	IsObjectNamespacedFn func(call int, obj runtime.Object) (bool, error)
 	RESTMapperFn         func(call int) meta.RESTMapper
 	numCalls             int
+	calledSubresources   []string
 }
 
 func (c *FakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -63,15 +64,23 @@ func (c *FakeClient) RESTMapper() meta.RESTMapper {
 }
 
 func (c *FakeClient) SubResource(subResource string) client.SubResourceClient {
-	defer func() { c.numCalls++ }()
+	defer func() {
+		c.numCalls++
+		c.calledSubresources = append(c.calledSubresources, subResource)
+	}()
 	if c.SubResourceFn != nil {
 		return c.SubResourceFn(subResource)
 	}
+
 	return NewFakeSubResourceWriter()
 }
 
 func (c *FakeClient) NumCalls() int {
 	return c.numCalls
+}
+
+func (c *FakeClient) CalledSubresources() []string {
+	return c.calledSubresources
 }
 
 type FakeSubResourceWriter struct {

--- a/pkg/client/testing/fake_client_test.go
+++ b/pkg/client/testing/fake_client_test.go
@@ -99,6 +99,7 @@ func TestFakeClient(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, called)
 		assert.Equal(t, 1, c.NumCalls())
+		assert.Empty(t, c.CalledSubresources())
 	})
 
 	t.Run("IsObjectNamespaced", func(t *testing.T) {
@@ -145,6 +146,7 @@ func TestFakeClient(t *testing.T) {
 		assert.Nil(t, sw)
 		assert.True(t, called)
 		assert.Equal(t, 1, c.NumCalls())
+		assert.Equal(t, []string{"status"}, c.CalledSubresources())
 	})
 
 	t.Run("SubResource - without Fn", func(t *testing.T) {

--- a/pkg/engine/operations/patch/operation.go
+++ b/pkg/engine/operations/patch/operation.go
@@ -23,6 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+const (
+	annotationPatchSubresource = "chainsaw.kyverno.io/patch-subresource"
+	fieldMetadata              = "metadata"
+	fieldAnnotations           = "annotations"
+)
+
 type operation struct {
 	compilers   compilers.Compilers
 	client      client.Client
@@ -134,6 +140,14 @@ func (o *operation) tryPatchResource(ctx context.Context, bindings apis.Bindings
 }
 
 func (o *operation) updateResource(ctx context.Context, bindings apis.Bindings, actual *unstructured.Unstructured, obj unstructured.Unstructured) (outputs.Outputs, error) {
+	sr := evaluateSubresourcePatch(&obj)
+	removePatchSubresourceAnnotation(&obj)
+
+	if sr == "" {
+		// fallback use patch action subresource
+		sr = o.subresource
+	}
+
 	patched, err := client.PatchObject(actual, &obj)
 	if err != nil {
 		return nil, err
@@ -142,10 +156,29 @@ func (o *operation) updateResource(ctx context.Context, bindings apis.Bindings, 
 	if err != nil {
 		return nil, err
 	}
-	if o.subresource != "" {
-		return o.handleCheck(ctx, bindings, obj, o.client.SubResource(o.subresource).Patch(ctx, actual, client.RawPatch(types.MergePatchType, bytes)))
+
+	if sr != "" {
+		return o.handleCheck(ctx, bindings, obj, o.client.SubResource(sr).Patch(ctx, actual, client.RawPatch(types.MergePatchType, bytes)))
 	}
 	return o.handleCheck(ctx, bindings, obj, o.client.Patch(ctx, actual, client.RawPatch(types.MergePatchType, bytes)))
+}
+
+func evaluateSubresourcePatch(obj *unstructured.Unstructured) string {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+
+	return annotations[annotationPatchSubresource]
+}
+
+// Don't add chainsaw annotation to patch.
+func removePatchSubresourceAnnotation(obj *unstructured.Unstructured) {
+	unstructured.RemoveNestedField(obj.Object, fieldMetadata, fieldAnnotations, annotationPatchSubresource)
+
+	if len(obj.GetAnnotations()) == 0 {
+		unstructured.RemoveNestedField(obj.Object, fieldMetadata, fieldAnnotations)
+	}
 }
 
 func (o *operation) handleCheck(ctx context.Context, bindings apis.Bindings, obj unstructured.Unstructured, err error) (_outputs outputs.Outputs, _err error) {

--- a/pkg/engine/operations/patch/operation_test.go
+++ b/pkg/engine/operations/patch/operation_test.go
@@ -47,12 +47,13 @@ func Test_create(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		object      unstructured.Unstructured
-		client      *tclient.FakeClient
-		expect      []v1alpha1.Expectation
-		expectedErr error
-		subresource string
+		name                  string
+		object                unstructured.Unstructured
+		client                *tclient.FakeClient
+		expect                []v1alpha1.Expectation
+		expectedErr           error
+		subresource           string
+		expectSubresourceName string
 	}{{
 		name:   "Resource doesn't exist",
 		object: pod,
@@ -220,9 +221,35 @@ func Test_create(t *testing.T) {
 				return nil
 			},
 		},
-		expect:      nil,
-		expectedErr: nil,
-		subresource: "status",
+		expect:                nil,
+		expectedErr:           nil,
+		subresource:           "status",
+		expectSubresourceName: "status",
+	}, {
+		name:   "Dry Run Subresource Resource annotation exists, patch it",
+		object: withSubresourcePatch(pod, "status"),
+		client: &tclient.FakeClient{
+			GetFn: func(ctx context.Context, _ int, _ client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				*obj.(*unstructured.Unstructured) = pod
+				return nil
+			},
+		},
+		expect:                nil,
+		expectedErr:           nil,
+		expectSubresourceName: "status",
+	}, {
+		name:   "Dry Run Subresource Resource annotation exists, it overwrites the patch subresource, patch it",
+		object: withSubresourcePatch(pod, "status"),
+		client: &tclient.FakeClient{
+			GetFn: func(ctx context.Context, _ int, _ client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				*obj.(*unstructured.Unstructured) = pod
+				return nil
+			},
+		},
+		expect:                nil,
+		expectedErr:           nil,
+		subresource:           "foo",
+		expectSubresourceName: "status",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -247,6 +274,9 @@ func Test_create(t *testing.T) {
 				assert.EqualError(t, err, tt.expectedErr.Error())
 			} else {
 				assert.NoError(t, err)
+			}
+			if tt.expectSubresourceName != "" {
+				assert.Equal(t, []string{tt.expectSubresourceName}, tt.client.CalledSubresources())
 			}
 		})
 	}
@@ -434,6 +464,118 @@ func Test_retry_logic(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func withSubresourcePatch(obj unstructured.Unstructured, subresource string) unstructured.Unstructured {
+	patchedObject := obj.DeepCopy()
+
+	annotations := patchedObject.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[annotationPatchSubresource] = subresource
+	patchedObject.SetAnnotations(annotations)
+
+	return *patchedObject
+}
+
+func Test_evaluateSubresourcePatch(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *unstructured.Unstructured
+		want string
+	}{
+		{
+			name: "no annotations",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "other annotations",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "patch subresource annotation",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							annotationPatchSubresource: "status",
+						},
+					},
+				},
+			},
+			want: "status",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateSubresourcePatch(tt.obj)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_removePatchSubresourceAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        map[string]string
+	}{
+		{
+			name:        "no annotations",
+			annotations: map[string]string{},
+			want:        nil,
+		},
+		{
+			name: "other annotations",
+			annotations: map[string]string{
+				"foo": "bar",
+			},
+			want: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "patch subresource annotation only",
+			annotations: map[string]string{
+				annotationPatchSubresource: "status",
+			},
+			want: nil,
+		},
+		{
+			name: "patch subresource annotation and others",
+			annotations: map[string]string{
+				annotationPatchSubresource: "status",
+				"foo":                      "bar",
+			},
+			want: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			us := &unstructured.Unstructured{}
+			us.SetAnnotations(tt.annotations)
+			removePatchSubresourceAnnotation(us)
+			assert.Equal(t, tt.want, us.GetAnnotations())
 		})
 	}
 }

--- a/testdata/e2e/examples/patch/README.md
+++ b/testdata/e2e/examples/patch/README.md
@@ -7,7 +7,8 @@
 | # | Name | Bindings | Try | Catch | Finally | Cleanup |
 |:-:|---|:-:|:-:|:-:|:-:|:-:|
 | 1 | [step-1](#step-step-1) | 0 | 3 | 0 | 0 | 0 |
-| 2 | [step-2](#step-step-2) | 0 | 3 | 0 | 0 | 0 |
+| 2 | [step-2](#step-step-2) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [step-3](#step-step-3) | 0 | 3 | 0 | 0 | 0 |
 
 ### Step: `step-1`
 
@@ -24,6 +25,17 @@ Patch a ConfigMap
 ### Step: `step-2`
 
 Patch the 'status' subresource of a Pod
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `patch` | 0 | 0 | *No description* |
+
+### Step: `step-3`
+
+Patch the 'status' subresource of a Pod via patch annotation
 
 #### Try
 

--- a/testdata/e2e/examples/patch/chainsaw-test.yaml
+++ b/testdata/e2e/examples/patch/chainsaw-test.yaml
@@ -58,16 +58,43 @@ spec:
                   reason: TestReason
                   message: TestMessage
                   lastTransitionTime: "2026-03-28T10:51:35Z"
-      - assert:
+  - description: "Patch the 'status' subresource of a Pod via patch annotation"
+    try:
+      - apply:
           resource:
             apiVersion: v1
             kind: Pod
             metadata:
-              name: test-pod
+              name: test-pod-annotated
+            spec:
+              containers:
+                - name: test-container
+                  image: busybox
+      - patch:
+          resource:
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: test-pod-annotated
+              annotations:
+                chainsaw.kyverno.io/patch-subresource: status
             status:
               conditions:
                 - type: TestCondition
                   status: "True"
                   reason: TestReason
-                  message: TestMessage
+                  message: AnnotatedTestMessage
+                  lastTransitionTime: "2026-03-28T10:51:35Z"
+      - assert:
+          resource:
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: test-pod-annotated
+            status:
+              conditions:
+                - type: TestCondition
+                  status: "True"
+                  reason: TestReason
+                  message: AnnotatedTestMessage
                   lastTransitionTime: "2026-03-28T10:51:35Z"

--- a/website/docs/operations/patch.md
+++ b/website/docs/operations/patch.md
@@ -79,12 +79,38 @@ spec:
     - try:
         - patch:
             # specify resource inline, where a subresource is patched
-            subresoruce: status
+            subresource: status # the name of the subresource to be patched
             resource:
               apiVersion: v1
               kind: Pod
               metadata:
                 name: test-pod
+              status:
+                conditions:
+                  - type: TestCondition
+                    status: "True"
+                    reason: TestReason
+                    message: TestMessage
+                    lastTransitionTime: "2026-03-28T10:51:35Z"
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: example-subresource-annotation
+spec:
+  steps:
+    - try:
+        - patch:
+            # specify resource inline, where a subresource is patched
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: test-pod
+                annotations:
+                  # The name of the subresource to be patched.
+                  # A subresource defined via annotation wins against the subresource defined the Patch struct.
+                  chainsaw.kyverno.io/patch-subresource: status
               status:
                 conditions:
                   - type: TestCondition

--- a/website/docs/reference/apis/chainsaw.v1alpha1.md
+++ b/website/docs/reference/apis/chainsaw.v1alpha1.md
@@ -747,7 +747,10 @@ For multiple objects use labels.</p>
 - [Operation](#chainsaw-kyverno-io-v1alpha1-Operation)
 
 <p>Patch represents a set of resources that should be patched.
-If a resource doesn't exist yet in the cluster it will fail.</p>
+If a resource doesn't exist yet in the cluster it will fail.
+Subresources can be patched by adding the annotation &quot;chainsaw.kyverno.io/patch-subresource&quot;,
+where the value is the name of the subresource to be patched, to the resource. A subresource defined via
+annotation wins against the subresource defined the Patch struct.</p>
 
 
 | Field | Type | Required | Inline | Description |


### PR DESCRIPTION
## Explanation

This PR extend subresource patches to be defined via inline patch annotation.

Sample:

```yaml
apiVersion: chainsaw.kyverno.io/v1alpha1
kind: Test
metadata:
  name: basic-deployment
spec:
  steps:
    - name: deploy-application
        - description: Simulate Readiness of provider resources
          patch:
            file: 02-patch-provider-resources.yaml
```

with the patch file: 02-patch-provider-resources.yaml
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: basic-deployment-dev-app
  namespace: basic-deployment-dev
status:
  sync:
    status: OutOfSync
---
apiVersion: identity.vault.m.upbound.io/v1alpha1
kind: GroupAlias
metadata:
  name: basic-deployment-owner
  namespace: crossplane-resources
  annotations:
   # define the name of the subresource to be patched
    chainsaw.kyverno.io/patch-subresource: status
status:
  conditions:
    - type: Ready
      status: "True"
      reason: ManuallySet
      message: Patched via chainsaw
      lastTransitionTime: "2026-03-28T10:51:35Z"
```

## Related issue

#2654

## Proposed Changes

Resources used i the patch action can define subresources via an annotation `chainsaw.kyverno.io/patch-subresource: status`. where each resource can define its own subresource.

In addition to #2654 where the subresource is defined for all resources in a patch action, the annotation based approach allows patching the default resource and different subresources in the same patch action.

The annotations are removed before the patch is applied.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

