### PR TITLE
feat: propagate step outputs across steps

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -187,8 +187,9 @@ func (r *runner) run(ctx context.Context, m mainstart, nsOptions v1alpha2.Namesp
 							info := StepInfo{
 								Id: i + 1,
 							}
-							tc := tc.WithBinding("step", info)
-							if stop := r.runStep(ctx, t.Cleanup, t.Fail, t.Failed, tc, step, report); stop {
+							var stop bool
+							stop, tc = r.runStep(ctx, t.Cleanup, t.Fail, t.Failed, tc.WithBinding("step", info), step, report)
+							if stop {
 								return
 							}
 						}
@@ -243,7 +244,8 @@ func (r *runner) runStep(
 	tc enginecontext.TestContext,
 	step v1alpha1.TestStep,
 	testReport *model.TestReport,
-) bool {
+) (stop bool, outTc enginecontext.TestContext) {
+	outTc = tc
 	report := &model.StepReport{
 		Name:      step.Name,
 		StartTime: time.Now(),
@@ -253,7 +255,7 @@ func (r *runner) runStep(
 		testReport.Add(report)
 	}()
 	if step.Compiler != nil {
-		tc = tc.WithDefaultCompiler(string(*step.Compiler))
+		outTc = outTc.WithDefaultCompiler(string(*step.Compiler))
 	}
 	contextData := enginecontext.ContextData{
 		Catch:               step.Catch,
@@ -264,14 +266,15 @@ func (r *runner) runStep(
 		Templating:          step.Template,
 		Timeouts:            step.Timeouts,
 	}
-	tc, err := enginecontext.SetupContextAndBindings(tc, contextData, step.Bindings...)
+	outTc, err := enginecontext.SetupContextAndBindings(outTc, contextData, step.Bindings...)
 	if err != nil {
 		fail()
 		logging.Log(ctx, logging.Internal, logging.ErrorStatus, nil, color.BoldRed, logging.ErrSection(err))
 		r.onFail()
-		return true
+		stop = true
+		return
 	}
-	cleaner := cleaner.New(tc.Timeouts().Cleanup, true, tc.DelayBeforeCleanup(), tc.DeletionPropagation())
+	cleaner := cleaner.New(outTc.Timeouts().Cleanup, true, outTc.DelayBeforeCleanup(), outTc.DeletionPropagation())
 	cleanup(func() {
 		if !cleaner.Empty() || len(step.Cleanup) != 0 {
 			report := &model.StepReport{
@@ -297,13 +300,13 @@ func (r *runner) runStep(
 			}
 			for i, operation := range step.Cleanup {
 				if operation.Compiler != nil {
-					tc = tc.WithDefaultCompiler(string(*operation.Compiler))
+					outTc = outTc.WithDefaultCompiler(string(*operation.Compiler))
 				}
-				outputsTc, err := r.runCatch(ctx, tc, operation, i)
+				outputsTc, err := r.runCatch(ctx, outTc, operation, i)
 				if err != nil {
 					fail()
 				}
-				tc = outputsTc
+				outTc = outputsTc
 			}
 		}
 	})
@@ -315,17 +318,17 @@ func (r *runner) runStep(
 			}()
 			for i, operation := range step.Finally {
 				if operation.Compiler != nil {
-					tc = tc.WithDefaultCompiler(string(*operation.Compiler))
+					outTc = outTc.WithDefaultCompiler(string(*operation.Compiler))
 				}
-				outputsTc, err := r.runCatch(ctx, tc, operation, i)
+				outputsTc, err := r.runCatch(ctx, outTc, operation, i)
 				if err != nil {
 					fail()
 				}
-				tc = outputsTc
+				outTc = outputsTc
 			}
 		}()
 	}
-	if catch := tc.Catch(); len(catch) != 0 {
+	if catch := outTc.Catch(); len(catch) != 0 {
 		defer func() {
 			if failed() {
 				logging.Log(ctx, logging.Catch, logging.BeginStatus, nil, color.BoldFgCyan)
@@ -334,13 +337,13 @@ func (r *runner) runStep(
 				}()
 				for i, operation := range catch {
 					if operation.Compiler != nil {
-						tc = tc.WithDefaultCompiler(string(*operation.Compiler))
+						outTc = outTc.WithDefaultCompiler(string(*operation.Compiler))
 					}
-					outputsTc, err := r.runCatch(ctx, tc, operation, i)
+					outputsTc, err := r.runCatch(ctx, outTc, operation, i)
 					if err != nil {
 						fail()
 					}
-					tc = outputsTc
+					outTc = outputsTc
 				}
 			}
 		}()
@@ -350,16 +353,17 @@ func (r *runner) runStep(
 		logging.Log(ctx, logging.Try, logging.EndStatus, nil, color.BoldFgCyan)
 	}()
 	for i, operation := range step.Try {
-		continueOnError, outputsTc, err := r.runOperation(ctx, tc, operation, i, cleaner, report)
+		continueOnError, outputsTc, err := r.runOperation(ctx, outTc, operation, i, cleaner, report)
 		if err != nil {
 			fail()
 			if !continueOnError {
-				return true
+				stop = true
+				return
 			}
 		}
-		tc = outputsTc
+		outTc = outputsTc
 	}
-	return false
+	return
 }
 
 func (r *runner) runOperation(

--- a/pkg/runner/step_test.go
+++ b/pkg/runner/step_test.go
@@ -802,7 +802,7 @@ func TestStepProcessor_Run(t *testing.T) {
 					Exec:    &config.Spec.Timeouts.Exec,
 				})
 			runner := runner{}
-			got := runner.runStep(ctx, cleanup, fail, failed, tcontext, tc.stepSpec, &model.TestReport{})
+			got, _ := runner.runStep(ctx, cleanup, fail, failed, tcontext, tc.stepSpec, &model.TestReport{})
 			assert.Equal(t, tc.want, got)
 			assert.Equal(t, tc.expectedFail, _failed)
 		})


### PR DESCRIPTION
## Explanation

Currently, outputs defined in a test step are only available within that same step.
This PR propagates outputs across steps, so a binding set via `outputs` in step N is
available in step N+1 and beyond. This is an addition of new behavior.

## Related issue

Fixes #2464


## Proposed Changes


`runStep` now returns the updated `TestContext` (including output bindings) in addition to the stop signal.
The step loop passes this context to subsequent steps, making outputs from one step available in the next.

Named return values are used so that `catch`/`finally` deferred blocks can also propagate their outputs —
without them, deferred changes to the context would be lost before the function returns.

**Story Proces**
1. Prior to this PR, outputs were scoped to a single step — a binding set via `outputs` 
   in step N could not be referenced in step N+1.

2. This PR returns the updated `TestContext` from `runStep` and passes it to subsequent 
   steps in the step loop.

3. After this PR, outputs from step N are available as bindings in all following steps.


**Proof Manifest**
```
apiVersion: chainsaw.kyverno.io/v1alpha1
kind: Test
metadata:
  name: step-outputs
spec:
  steps:
  - name: get-namespace-name
    try:
    - script:
        content: echo $NAMESPACE
        outputs:
        - name: ns
          value: (trim_space($stdout))
  - name: assert-namespace-exists
    try:
    - assert:
        resource:
          apiVersion: v1
          kind: Namespace
          metadata:
            name: ($ns)
```




## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->