### PR TITLE
feat: include scenario name and id in test reports

### DIFF
--- a/pkg/model/report.go
+++ b/pkg/model/report.go
@@ -38,14 +38,23 @@ func (r *Report) Add(report *TestReport) {
 }
 
 type TestReport struct {
-	BasePath   string
-	Name       string
-	Concurrent *bool
-	StartTime  time.Time
-	EndTime    time.Time
-	Namespace  string
-	Skipped    bool
-	Steps      []*StepReport
+	BasePath     string
+	Name         string
+	ScenarioId   int
+	ScenarioName string
+	Concurrent   *bool
+	StartTime    time.Time
+	EndTime      time.Time
+	Namespace    string
+	Skipped      bool
+	Steps        []*StepReport
+}
+
+func (r *TestReport) DisplayName() string {
+	if r.ScenarioName == "" {
+		return r.Name
+	}
+	return fmt.Sprintf("%s [%s]", r.Name, r.ScenarioName)
 }
 
 func (r *TestReport) Add(report *StepReport) {

--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -28,14 +28,16 @@ func saveJson(report *model.Report, file string) error {
 		Operations []OperationReport `json:"operations,omitempty"`
 	}
 	type TestReport struct {
-		BasePath   string       `json:"basePath,omitempty"`
-		Name       string       `json:"name,omitempty"`
-		Concurrent *bool        `json:"concurrent,omitempty"`
-		Status     string       `json:"status"`
-		StartTime  time.Time    `json:"startTime"`
-		EndTime    time.Time    `json:"endTime"`
-		Namespace  string       `json:"namespace,omitempty"`
-		Steps      []StepReport `json:"steps,omitempty"`
+		BasePath     string       `json:"basePath,omitempty"`
+		Name         string       `json:"name,omitempty"`
+		ScenarioId   int          `json:"scenarioId,omitempty"`
+		ScenarioName string       `json:"scenario,omitempty"`
+		Concurrent   *bool        `json:"concurrent,omitempty"`
+		Status       string       `json:"status"`
+		StartTime    time.Time    `json:"startTime"`
+		EndTime      time.Time    `json:"endTime"`
+		Namespace    string       `json:"namespace,omitempty"`
+		Steps        []StepReport `json:"steps,omitempty"`
 	}
 	type Report struct {
 		Name      string       `json:"name,omitempty"`
@@ -56,13 +58,15 @@ func saveJson(report *model.Report, file string) error {
 			testStatus = "failed"
 		}
 		testReport := TestReport{
-			BasePath:   test.BasePath,
-			Name:       test.Name,
-			Concurrent: test.Concurrent,
-			Status:     testStatus,
-			StartTime:  test.StartTime,
-			EndTime:    test.EndTime,
-			Namespace:  test.Namespace,
+			BasePath:     test.BasePath,
+			Name:         test.Name,
+			ScenarioId:   test.ScenarioId,
+			ScenarioName: test.ScenarioName,
+			Concurrent:   test.Concurrent,
+			Status:       testStatus,
+			StartTime:    test.StartTime,
+			EndTime:      test.EndTime,
+			Namespace:    test.Namespace,
 		}
 		for _, step := range test.Steps {
 			stepStatus := "passed"

--- a/pkg/report/junit.go
+++ b/pkg/report/junit.go
@@ -27,7 +27,7 @@ func saveJUnitTest(report *model.Report, file string) error {
 		}
 		for _, test := range tests {
 			testCase := junit.Testcase{
-				Name: test.Name,
+				Name: test.DisplayName(),
 				Time: durationInSecondsString(test.StartTime, test.EndTime),
 			}
 			if test.Skipped {
@@ -72,15 +72,18 @@ func saveJUnitStep(report *model.Report, file string) error {
 	}
 	addTestSuite := func(test *model.TestReport) {
 		testSuite := junit.Testsuite{
-			Name:    test.Name,
+			Name:    test.DisplayName(),
 			Package: test.BasePath,
 			Time:    durationInSecondsString(test.StartTime, test.EndTime),
 		}
 		testSuite.SetTimestamp(report.StartTime)
 		testSuite.AddProperty("namespace", test.Namespace)
+		if test.ScenarioName != "" {
+			testSuite.AddProperty("scenario", test.ScenarioName)
+		}
 		if test.Skipped {
 			testCase := junit.Testcase{
-				Name: test.Name,
+				Name: test.DisplayName(),
 				Time: durationInSecondsString(test.StartTime, test.EndTime),
 			}
 			testCase.Skipped = &junit.Result{}
@@ -124,15 +127,18 @@ func saveJUnitOperation(report *model.Report, file string) error {
 	}
 	addTestSuite := func(test *model.TestReport) {
 		testSuite := junit.Testsuite{
-			Name:    test.Name,
+			Name:    test.DisplayName(),
 			Package: test.BasePath,
 			Time:    durationInSecondsString(test.StartTime, test.EndTime),
 		}
 		testSuite.SetTimestamp(report.StartTime)
 		testSuite.AddProperty("namespace", test.Namespace)
+		if test.ScenarioName != "" {
+			testSuite.AddProperty("scenario", test.ScenarioName)
+		}
 		if test.Skipped {
 			testCase := junit.Testcase{
-				Name: test.Name,
+				Name: test.DisplayName(),
 				Time: durationInSecondsString(test.StartTime, test.EndTime),
 			}
 			testCase.Skipped = &junit.Result{}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -111,10 +111,12 @@ func (r *runner) run(ctx context.Context, m mainstart, nsOptions v1alpha2.Namesp
 						}
 						// setup reporting
 						report := &model.TestReport{
-							BasePath:   test.BasePath,
-							Name:       test.Test.Name,
-							Concurrent: test.Test.Spec.Concurrent,
-							StartTime:  time.Now(),
+							BasePath:     test.BasePath,
+							Name:         test.Test.Name,
+							ScenarioId:   scenarioId,
+							ScenarioName: scenarioName,
+							Concurrent:   test.Test.Spec.Concurrent,
+							StartTime:    time.Now(),
 						}
 						defer func() {
 							report.EndTime = time.Now()


### PR DESCRIPTION
## Explanation

When a test defines scenarios, Chainsaw runs the test once per scenario. The terminal output already shows which scenario is running, but the generated reports did not.
This PR fixes that by carrying the scenario name and scenario id through to the report output. It is an additive, backwards-compatible change: tests without scenarios produce exactly the same reports as before.




## Proposed Changes

- `model.TestReport` gains `ScenarioId` and `ScenarioName`, plus a `DisplayName()` helper that returns `<test-name> [<scenario-name>]` when a scenario is set, and the plain test name otherwise.
- `runner` populates both fields when building the test report. The scenario name comes from `names.Scenario(...)`, so unnamed scenarios fall back to `scenario #N`, consistent with the terminal logger.

### Proof Manifests
```
apiVersion: chainsaw.kyverno.io/v1alpha1
kind: Test
metadata:
  name: scenario-report
spec:
  scenarios:
    - name: variant-a
      bindings:
        - name: message
          value: hello
    - name: variant-b
      bindings:
        - name: message
          value: goodbye
  steps:
    - try:
        - script:
            env:
              - name: message
                value: ($message)
            content: echo $message
            check:
              (trim_space($stdout)): ($message)
```

```
chainsaw test scenario-report --no-cluster --report-format JSON --report-path .
```


**Before**
```
"tests": [
  {
    "basePath": "testdata/e2e/examples/scenario-report",
    "name": "scenario-report",
    "status": "passed",
    ...
  },
  {
    "basePath": "testdata/e2e/examples/scenario-report",
    "name": "scenario-report",
    "status": "passed",
    ...
  }
]
```



**After**
```
"tests": [
  {
    "basePath": "testdata/e2e/examples/scenario-report",
    "name": "scenario-report",
    "scenarioId": 2,
    "scenario": "variant-b",
    "status": "passed",
    ...
  },
  {
    "basePath": "testdata/e2e/examples/scenario-report",
    "name": "scenario-report",
    "scenarioId": 1,
    "scenario": "variant-a",
    "status": "passed",
    ...
  }
]
```

Same run with `--report-format JUNIT-TEST`
```
<!-- before -->
<testcase name="scenario-report" classname="" time="0.008511"></testcase>
<testcase name="scenario-report" classname="" time="0.008824"></testcase>

<!-- after -->
<testcase name="scenario-report [variant-b]" classname="" time="0.008511"></testcase>
<testcase name="scenario-report [variant-a]" classname="" time="0.008824"></testcase>
```


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
